### PR TITLE
JN "Basic Usage of DataMapPlot": Fix typos

### DIFF
--- a/doc/basic_usage.ipynb
+++ b/doc/basic_usage.ipynb
@@ -57,7 +57,7 @@
    "id": "b8dc4a93-aac6-40a4-be77-8c3ac85ef7a1",
    "metadata": {},
    "source": [
-    "What does the data actually look like? The data map provides a two dimensional location for each paragraph, and is thus a 2d numpy array fo float values:"
+    "What does the data actually look like? The data map provides a two dimensional location for each paragraph, and is thus a 2d numpy array of float values:"
    ]
   },
   {
@@ -121,7 +121,7 @@
    "id": "8163001f-4d8c-477b-9552-4b8a2e8540ff",
    "metadata": {},
    "source": [
-    "The topic label data is an array of text entries, with paragraphs that didn't fall into a specific topic (at the given clustering granularity) given the label ``'Unlabelled'``. Note that we have a label entry for each and every paragraph from the orginal dataset."
+    "The topic label data is an array of text entries, with paragraphs that didn't fall into a specific topic (at the given clustering granularity) given the label ``'Unlabelled'``. Note that we have a label entry for each and every paragraph from the original dataset."
    ]
   },
   {
@@ -219,7 +219,7 @@
    "id": "2bebc0d2-5179-40ad-acc6-d8ea9fd44a14",
    "metadata": {},
    "source": [
-    "As you can see, just handing DataMapPlot the data map and labels is enough to generate an attractive plot with all the clusters labelled. The default colour palette is designed such that nearby topics should have similar colours, but with enough variation to distinguish the topics. The labels are layed out in rings around the data map, which indicator arrows pointing to the cluster in the data map that the label refers to. By default the text labels are also coloured to match thematically with the colour of the cluster they are attached to, aiding in picking out which cluster the label refers to (see, for example, the \"Religion and Deities\" cluster above). DataMapPlot also attempts to make good choices about representing the data map itself; in particular for data maps with many points it defaults to using [datashader](https://datashader.org/) for rendering the data map, avoiding many [issues associated with overplotting and other associated plotting pitfalls](https://datashader.org/user_guide/Plotting_Pitfalls.html). Again, by default, DataMapPlot also adds a Kernel Density Estimate (KDE) based \"glow\" around clusters which can help highlight extremely small dense clusters; this can be turned off easily if required. All of this can be tweaked and adjusted, but the goal of DataMapPlot is to try to make good choices for you, and avoid hours of carefully tweaking the plot yourself by hand to get things \"just right\".\n",
+    "As you can see, just handing DataMapPlot the data map and labels is enough to generate an attractive plot with all the clusters labelled. The default colour palette is designed such that nearby topics should have similar colours, but with enough variation to distinguish the topics. The labels are laid out in rings around the data map, which indicator arrows pointing to the cluster in the data map that the label refers to. By default the text labels are also coloured to match thematically with the colour of the cluster they are attached to, aiding in picking out which cluster the label refers to (see, for example, the \"Religion and Deities\" cluster above). DataMapPlot also attempts to make good choices about representing the data map itself; in particular for data maps with many points it defaults to using [datashader](https://datashader.org/) for rendering the data map, avoiding many [issues associated with overplotting and other associated plotting pitfalls](https://datashader.org/user_guide/Plotting_Pitfalls.html). Again, by default, DataMapPlot also adds a Kernel Density Estimate (KDE) based \"glow\" around clusters which can help highlight extremely small dense clusters; this can be turned off easily if required. All of this can be tweaked and adjusted, but the goal of DataMapPlot is to try to make good choices for you, and avoid hours of carefully tweaking the plot yourself by hand to get things \"just right\".\n",
     "\n",
     "One thing to note here is that there are *a lot* of topics to be labelled. In fact there are fifty different text labels that have to placed in the plot. Nonetheless DataMapPlot has managed to find a reasonable layout that avoids overlapping text or crossing indicator lines. In practice DataMapPlot can handling up to 64 labels reasonably well; beyond that it will continue to function, and do it's best (now with three or more rings of labels), but label layout will be challenging and no promises can be made about the quality of the aesthetics in the result.\n",
     "\n",
@@ -609,7 +609,7 @@
    "id": "68acf8c6-eb9a-48d0-9642-3c6e5e00ef2a",
    "metadata": {},
    "source": [
-    "By default DataMapPlot assumes that unclustered points are given the label ``\"Unlabelled\"``, but that isn't required. We can specify a name for the unclustered point label using the ``noise_label`` keyword argument to ``create_plot``. Lert's see how our simplified label set looks:"
+    "By default DataMapPlot assumes that unclustered points are given the label ``\"Unlabelled\"``, but that isn't required. We can specify a name for the unclustered point label using the ``noise_label`` keyword argument to ``create_plot``. Let's see how our simplified label set looks:"
    ]
   },
   {


### PR DESCRIPTION
This PR aims to fix a few typos in the Jupyter notebook "Basic Usage of DataMapPlot".