### PR TITLE
Add custom transparency to interactive plots

### DIFF
--- a/datamapplot/create_plots.py
+++ b/datamapplot/create_plots.py
@@ -173,7 +173,9 @@ def create_plot(
     if labels is None:
         label_locations = np.zeros((0, 2), dtype=np.float32)
         label_text = []
-        cluster_label_vector = np.full(data_map_coords.shape[0], "Unlabelled", dtype=object)
+        cluster_label_vector = np.full(
+            data_map_coords.shape[0], "Unlabelled", dtype=object
+        )
         unique_non_noise_labels = []
     else:
         cluster_label_vector = np.asarray(labels)
@@ -269,9 +271,9 @@ def create_plot(
         label_arrow_colors = None
 
     cluster_sizes = pd.Series(cluster_label_vector).value_counts()
-    label_cluster_sizes = np.asarray([
-            cluster_sizes[x] for x in unique_non_noise_labels
-    ])
+    label_cluster_sizes = np.asarray(
+        [cluster_sizes[x] for x in unique_non_noise_labels]
+    )
 
     # Heuristics for point size and alpha values
     n_points = data_map_coords.shape[0]
@@ -334,6 +336,7 @@ def create_interactive_plot(
     cmap=None,
     marker_size_array=None,
     marker_color_array=None,
+    marker_alpha_array=None,
     use_medoids=False,
     cluster_boundary_polygons=False,
     color_cluster_boundaries=True,
@@ -419,6 +422,9 @@ def create_interactive_plot(
 
     marker_size_array: np.ndarray or None (optional, default=None)
         An array of sizes for each of the points in the data map scatterplot.
+
+    marker_alpha_array: np.ndarray or None (optional, default=None)
+        An array of alpha values for each of the points in the data map scatterplot.
 
     use_medoids: bool (optional, default=False)
         Whether to use medoids instead of centroids to determine the "location" of the cluster,
@@ -587,6 +593,10 @@ def create_interactive_plot(
     point_dataframe["g"] = color_vector.T[1].astype(np.uint8)
     point_dataframe["b"] = color_vector.T[2].astype(np.uint8)
     point_dataframe["a"] = np.uint8(180)
+    if marker_alpha_array is not None:
+        if (marker_alpha_array <= 1).all():
+            marker_alpha_array *= 255
+        point_dataframe["a"] = marker_alpha_array.astype(np.uint8)
 
     html_str = render_html(
         point_dataframe,

--- a/datamapplot/create_plots.py
+++ b/datamapplot/create_plots.py
@@ -173,9 +173,7 @@ def create_plot(
     if labels is None:
         label_locations = np.zeros((0, 2), dtype=np.float32)
         label_text = []
-        cluster_label_vector = np.full(
-            data_map_coords.shape[0], "Unlabelled", dtype=object
-        )
+        cluster_label_vector = np.full(data_map_coords.shape[0], "Unlabelled", dtype=object)
         unique_non_noise_labels = []
     else:
         cluster_label_vector = np.asarray(labels)
@@ -271,8 +269,8 @@ def create_plot(
         label_arrow_colors = None
 
     cluster_sizes = pd.Series(cluster_label_vector).value_counts()
-    label_cluster_sizes = np.asarray(
-        [cluster_sizes[x] for x in unique_non_noise_labels]
+    label_cluster_sizes = np.asarray([
+        cluster_sizes[x] for x in unique_non_noise_labels]
     )
 
     # Heuristics for point size and alpha values

--- a/datamapplot/create_plots.py
+++ b/datamapplot/create_plots.py
@@ -173,7 +173,9 @@ def create_plot(
     if labels is None:
         label_locations = np.zeros((0, 2), dtype=np.float32)
         label_text = []
-        cluster_label_vector = np.full(data_map_coords.shape[0], "Unlabelled", dtype=object)
+        cluster_label_vector = np.full(
+            data_map_coords.shape[0], "Unlabelled", dtype=object
+        )
         unique_non_noise_labels = []
     else:
         cluster_label_vector = np.asarray(labels)
@@ -269,8 +271,8 @@ def create_plot(
         label_arrow_colors = None
 
     cluster_sizes = pd.Series(cluster_label_vector).value_counts()
-    label_cluster_sizes = np.asarray([
-        cluster_sizes[x] for x in unique_non_noise_labels]
+    label_cluster_sizes = np.asarray(
+        [cluster_sizes[x] for x in unique_non_noise_labels]
     )
 
     # Heuristics for point size and alpha values

--- a/datamapplot/interactive_rendering.py
+++ b/datamapplot/interactive_rendering.py
@@ -826,7 +826,9 @@ def render_html(
 
             if on_click is not None:
                 on_click = (
-                    "({index, picked}, event) => { if (picked) {" + on_click.format_map(replacements) + " } }"
+                    "({index, picked}, event) => { if (picked) {"
+                    + on_click.format_map(replacements)
+                    + " } }"
                 )
         else:
             hover_data = point_dataframe[["hover_text"]]
@@ -841,7 +843,9 @@ def render_html(
 
             if on_click is not None:
                 on_click = (
-                    "({index, picked}, event) => { if (picked) {" + on_click.format_map(replacements) + " } }"
+                    "({index, picked}, event) => { if (picked) {"
+                    + on_click.format_map(replacements)
+                    + " } }"
                 )
     elif extra_point_data is not None:
         hover_data = extra_point_data
@@ -862,7 +866,9 @@ def render_html(
 
         if on_click is not None:
             on_click = (
-                "({index, picked}, event) => { if (picked) {" + on_click.format_map(replacements) + " } }"
+                "({index, picked}, event) => { if (picked) {"
+                + on_click.format_map(replacements)
+                + " } }"
             )
     else:
         hover_data = pd.DataFrame(columns=("hover_text",))
@@ -887,11 +893,18 @@ def render_html(
         base64_point_data = ""
         base64_hover_data = ""
         base64_label_data = ""
-        file_prefix = offline_data_prefix if offline_data_prefix is not None else "datamapplot"
-        point_data.to_feather(f"{file_prefix}_point_df.arrow", compression="uncompressed")
+        file_prefix = (
+            offline_data_prefix if offline_data_prefix is not None else "datamapplot"
+        )
+        point_data.to_feather(
+            f"{file_prefix}_point_df.arrow", compression="uncompressed"
+        )
         hover_data.to_feather("point_hover_data.arrow", compression="uncompressed")
         with zipfile.ZipFile(
-            f"{file_prefix}_point_hover_data.zip", "w", compression=zipfile.ZIP_DEFLATED, compresslevel=9,
+            f"{file_prefix}_point_hover_data.zip",
+            "w",
+            compression=zipfile.ZIP_DEFLATED,
+            compresslevel=9,
         ) as f:
             f.write("point_hover_data.arrow")
         os.remove("point_hover_data.arrow")

--- a/datamapplot/interactive_rendering.py
+++ b/datamapplot/interactive_rendering.py
@@ -225,7 +225,7 @@ _DECKGL_TEMPLATE_STR = """
                 data.src.r[index], 
                 data.src.g[index], 
                 data.src.b[index],
-                180
+                data.src.a[index],
             ]
         },
         getLineColor: (object, {index, data}) => {
@@ -538,6 +538,7 @@ def render_html(
     custom_html=None,
     custom_css=None,
     custom_js=None,
+    alpha=180 / 255,
 ):
     """Given data about points, and data about labels, render to an HTML file
     using Deck.GL to provide an interactive plot that can be zoomed, panned
@@ -750,7 +751,7 @@ def render_html(
         magic_number = point_size_scale / 100.0
     else:
         magic_number = np.clip(32 * 4 ** (-np.log10(n_points)), 0.005, 0.1)
-        
+
     if "size" not in point_dataframe.columns:
         point_size = magic_number
     else:
@@ -826,7 +827,11 @@ def render_html(
                 get_tooltip = "({index}) => hoverData.data.hover_text[index]"
 
             if on_click is not None:
-                on_click = "({index, picked}, event) => { if (picked) {" + on_click.format_map(replacements) + " } }"
+                on_click = (
+                    "({index, picked}, event) => { if (picked) {"
+                    + on_click.format_map(replacements)
+                    + " } }"
+                )
         else:
             hover_data = point_dataframe[["hover_text"]]
             get_tooltip = "({index}) => hoverData.data.hover_text[index]"
@@ -839,7 +844,11 @@ def render_html(
             )
 
             if on_click is not None:
-                on_click = "({index, picked}, event) => { if (picked) {" + on_click.format_map(replacements) + " } }"
+                on_click = (
+                    "({index, picked}, event) => { if (picked) {"
+                    + on_click.format_map(replacements)
+                    + " } }"
+                )
     elif extra_point_data is not None:
         hover_data = extra_point_data
         replacements = FormattingDict(
@@ -858,7 +867,11 @@ def render_html(
             get_tooltip = "null"
 
         if on_click is not None:
-            on_click = "({index, picked}, event) => { if (picked) {" + on_click.format_map(replacements) + " } }"
+            on_click = (
+                "({index, picked}, event) => { if (picked) {"
+                + on_click.format_map(replacements)
+                + " } }"
+            )
     else:
         hover_data = pd.DataFrame(columns=("hover_text",))
         get_tooltip = "null"
@@ -882,8 +895,12 @@ def render_html(
         base64_point_data = ""
         base64_hover_data = ""
         base64_label_data = ""
-        file_prefix = offline_data_prefix if offline_data_prefix is not None else "datamapplot"
-        point_data.to_feather(f"{file_prefix}_point_df.arrow", compression="uncompressed")
+        file_prefix = (
+            offline_data_prefix if offline_data_prefix is not None else "datamapplot"
+        )
+        point_data.to_feather(
+            f"{file_prefix}_point_df.arrow", compression="uncompressed"
+        )
         hover_data.to_feather("point_hover_data.arrow", compression="uncompressed")
         with zipfile.ZipFile(
             f"{file_prefix}_point_hover_data.zip",
@@ -895,7 +912,10 @@ def render_html(
         os.remove("point_hover_data.arrow")
         label_dataframe.to_json("label_data.json", orient="records")
         with zipfile.ZipFile(
-            f"{file_prefix}_label_data.zip", "w", compression=zipfile.ZIP_DEFLATED, compresslevel=9
+            f"{file_prefix}_label_data.zip",
+            "w",
+            compression=zipfile.ZIP_DEFLATED,
+            compresslevel=9,
         ) as f:
             f.write("label_data.json")
         os.remove("label_data.json")
@@ -929,7 +949,9 @@ def render_html(
         api_fontname = None
     if tooltip_font_family is not None:
         api_tooltip_fontname = tooltip_font_family.replace(" ", "+")
-        resp = requests.get(f"https://fonts.googleapis.com/css?family={api_tooltip_fontname}")
+        resp = requests.get(
+            f"https://fonts.googleapis.com/css?family={api_tooltip_fontname}"
+        )
         if not resp.ok:
             api_tooltip_fontname = None
     else:

--- a/datamapplot/interactive_rendering.py
+++ b/datamapplot/interactive_rendering.py
@@ -538,7 +538,6 @@ def render_html(
     custom_html=None,
     custom_css=None,
     custom_js=None,
-    alpha=180 / 255,
 ):
     """Given data about points, and data about labels, render to an HTML file
     using Deck.GL to provide an interactive plot that can be zoomed, panned

--- a/datamapplot/interactive_rendering.py
+++ b/datamapplot/interactive_rendering.py
@@ -750,7 +750,6 @@ def render_html(
         magic_number = point_size_scale / 100.0
     else:
         magic_number = np.clip(32 * 4 ** (-np.log10(n_points)), 0.005, 0.1)
-
     if "size" not in point_dataframe.columns:
         point_size = magic_number
     else:
@@ -827,9 +826,7 @@ def render_html(
 
             if on_click is not None:
                 on_click = (
-                    "({index, picked}, event) => { if (picked) {"
-                    + on_click.format_map(replacements)
-                    + " } }"
+                    "({index, picked}, event) => { if (picked) {" + on_click.format_map(replacements) + " } }"
                 )
         else:
             hover_data = point_dataframe[["hover_text"]]
@@ -844,9 +841,7 @@ def render_html(
 
             if on_click is not None:
                 on_click = (
-                    "({index, picked}, event) => { if (picked) {"
-                    + on_click.format_map(replacements)
-                    + " } }"
+                    "({index, picked}, event) => { if (picked) {" + on_click.format_map(replacements) + " } }"
                 )
     elif extra_point_data is not None:
         hover_data = extra_point_data
@@ -867,9 +862,7 @@ def render_html(
 
         if on_click is not None:
             on_click = (
-                "({index, picked}, event) => { if (picked) {"
-                + on_click.format_map(replacements)
-                + " } }"
+                "({index, picked}, event) => { if (picked) {" + on_click.format_map(replacements) + " } }"
             )
     else:
         hover_data = pd.DataFrame(columns=("hover_text",))
@@ -894,18 +887,11 @@ def render_html(
         base64_point_data = ""
         base64_hover_data = ""
         base64_label_data = ""
-        file_prefix = (
-            offline_data_prefix if offline_data_prefix is not None else "datamapplot"
-        )
-        point_data.to_feather(
-            f"{file_prefix}_point_df.arrow", compression="uncompressed"
-        )
+        file_prefix = offline_data_prefix if offline_data_prefix is not None else "datamapplot"
+        point_data.to_feather(f"{file_prefix}_point_df.arrow", compression="uncompressed")
         hover_data.to_feather("point_hover_data.arrow", compression="uncompressed")
         with zipfile.ZipFile(
-            f"{file_prefix}_point_hover_data.zip",
-            "w",
-            compression=zipfile.ZIP_DEFLATED,
-            compresslevel=9,
+            f"{file_prefix}_point_hover_data.zip", "w", compression=zipfile.ZIP_DEFLATED, compresslevel=9,
         ) as f:
             f.write("point_hover_data.arrow")
         os.remove("point_hover_data.arrow")


### PR DESCRIPTION
The static plots have the ability to pass an `alpha` array-like for the transparency of the points, I wanted to use this feature in interactive plots and it was fairly easy to add.

Most of the changes in the git diff are from running the black code formatter, lol

