### PR TITLE
Refactor the configuration system

### DIFF
--- a/datamapplot/config.py
+++ b/datamapplot/config.py
@@ -1,13 +1,32 @@
-from warnings import warn
+from collections.abc import Sequence
+import inspect as ins
 import json
-import platformdirs
 from pathlib import Path
+import platformdirs
+from typing import Any, Callable, cast, ParamSpec, TypeVar, Union
+from warnings import warn
+
+
+P = ParamSpec("P")
+T = TypeVar("T")
+
 
 DEFAULT_CONFIG = {
     "dpi": 100,
     "figsize": (10, 10),
     "cdn_url": "unpkg.com",
 }
+
+
+class ConfigError(Exception):
+
+    def __init__(self, message: str, parameter: ins.Parameter) -> None:
+        super().__init__(message)
+        self.parameter = parameter
+
+
+UnconfigurableParameters = Sequence[str]
+
 
 class ConfigManager:
     """Configuration manager for the datamapplot package."""
@@ -19,13 +38,13 @@ class ConfigManager:
             cls._instance = super(ConfigManager, cls).__new__(cls)
             cls._instance._config = {}
         return cls._instance
-    
+
     def __init__(self):
-        if self._instance is None:
+        if not self._config:
             self._config_dir = platformdirs.user_config_dir("datamapplot")
             self._config_file = Path(self._config_dir) / "config.json"
             self._config = DEFAULT_CONFIG.copy()
-            
+
             self._ensure_config_file()
             self._load_config()
 
@@ -33,13 +52,13 @@ class ConfigManager:
         """Create config directory and file if they don't exist."""
         try:
             self._config_file.parent.mkdir(parents=True, exist_ok=True)
-            
+
             if not self._config_file.exists():
                 with open(self._config_file, 'w') as f:
                     json.dump(DEFAULT_CONFIG, f, indent=2)
         except Exception as e:
             warn(f"Error creating config file: {e}")
-    
+
     def _load_config(self) -> None:
         """Load configuration from file."""
         try:
@@ -48,7 +67,7 @@ class ConfigManager:
                 self._config.update(loaded_config)
         except Exception as e:
             warn(f"Error loading config file: {e}")
-    
+
     def save(self) -> None:
         """Save current configuration to file."""
         try:
@@ -56,10 +75,10 @@ class ConfigManager:
                 json.dump(self._config, f, indent=2)
         except Exception as e:
             warn(f"Error saving config file: {e}")
-    
+
     def __getitem__(self, key):
         return self._config[key]
-    
+
     def __setitem__(self, key, value):
         self._config[key] = value
 
@@ -69,4 +88,50 @@ class ConfigManager:
     def __contains__(self, key):
         return key in self._config
 
-    
+    def complete(
+        self,
+        fn_or_unc: Union[None, UnconfigurableParameters, Callable[P, T]],
+        unconfigurable: UnconfigurableParameters = set(),
+    ) -> Union[Callable[[Callable[P, T]], Callable[P, T]], Callable[P, T]]:
+        def decorator(fn: Callable[P, T]) -> Callable[P, T]:
+            sig = ins.signature(fn)
+
+            def _complete(*args, **kwargs):
+                bound_args = sig.bind(*args, **kwargs)
+                bindings = bound_args.arguments
+                from_config = {}
+                for name, param in sig.parameters.items():
+                    if name not in bindings and name in self:
+                        if not _is_admissible(param):
+                            raise ConfigError(
+                                "Only keyword (or plausibly keyword) parameters "
+                                "can be set through the DataMapPlot configuration "
+                                f"file. Parameter {param.name} ({param.kind}) "
+                                "is thus not admissible.",
+                                param
+                            )
+                        if name in unconfigurable:
+                            raise ConfigError(
+                                f"Parameter {param.name} is deliberately listed as "
+                                "forbidden from being defined through the DataMapPlot "
+                                "configuration file.",
+                                param
+                            )
+                        from_config[name] = self[name]
+                return fn(*bound_args.args, **(bound_args.kwargs | from_config))
+
+            return _complete
+
+        if fn_or_unc is None:
+            return decorator
+        elif not hasattr(fn_or_unc, "__call__"):
+            unconfigurable = cast(UnconfigurableParameters, fn_or_unc)
+            return decorator
+        return decorator(fn_or_unc)
+
+
+_KINDS_ADMISSIBLE = {ins.Parameter.POSITIONAL_OR_KEYWORD, ins.Parameter.KEYWORD_ONLY}
+
+
+def _is_admissible(param: ins.Parameter) -> bool:
+    return param.kind in _KINDS_ADMISSIBLE

--- a/datamapplot/create_plots.py
+++ b/datamapplot/create_plots.py
@@ -2,7 +2,6 @@ import numpy as np
 import pandas as pd
 import textwrap
 import colorcet
-import inspect
 
 from matplotlib import pyplot as plt
 from matplotlib.colors import to_rgb
@@ -23,6 +22,10 @@ from datamapplot.interactive_rendering import (
 from datamapplot.config import ConfigManager
 
 
+cfg = ConfigManager()
+
+
+@cfg.complete(unconfigurable={"data_map_coords", "labels"})
 def create_plot(
     data_map_coords,
     labels=None,
@@ -172,19 +175,6 @@ def create_plot(
         The axes contained within the figure that the plot is rendered to.
 
     """
-    function_signature = inspect.signature(create_plot)
-    function_args = locals()
-    config = ConfigManager()
-
-    for param_name, param_value in function_signature.parameters.items():
-        if param_name in ("data_map_coords", "labels"):
-            continue
-        
-        provided_value = function_args.get(param_name)
-        if provided_value == param_value.default:
-            if param_name in config:
-                function_args[param_name] = config[param_name]
-
     if labels is None:
         label_locations = np.zeros((0, 2), dtype=np.float32)
         label_text = []
@@ -333,6 +323,7 @@ def create_plot(
     return fig, ax
 
 
+@cfg.complete(unconfigurable={"data_map_coords", "label_layers", "hover_text"})
 def create_interactive_plot(
     data_map_coords,
     *label_layers,
@@ -472,19 +463,6 @@ def create_interactive_plot(
     -------
 
     """
-    function_signature = inspect.signature(create_interactive_plot)
-    function_args = locals()
-    config = ConfigManager()
-
-    for param_name, param_value in function_signature.parameters.items():
-        if param_name in ("data_map_coords", "label_layers", "hover_text"):
-            continue
-
-        provided_value = function_args.get(param_name)
-        if provided_value is param_value.default:
-            if param_name in config:
-                function_args[param_name] = config[param_name]
-
     if len(label_layers) == 0:
         label_dataframe = pd.DataFrame(
             {

--- a/datamapplot/interactive_rendering.py
+++ b/datamapplot/interactive_rendering.py
@@ -6,7 +6,6 @@ import os
 import warnings
 import zipfile
 import json
-import inspect
 
 import jinja2
 import numpy as np
@@ -30,6 +29,9 @@ from datamapplot.histograms import (
 from datamapplot.alpha_shapes import create_boundary_polygons, smooth_polygon
 from datamapplot.medoids import medoid
 from datamapplot.config import ConfigManager
+
+
+cfg = ConfigManager()
 
 _DECKGL_TEMPLATE_STR = (files("datamapplot") / "deckgl_template.html").read_text(
     encoding="utf-8"
@@ -397,6 +399,7 @@ def label_text_and_polygon_dataframes(
     return pd.DataFrame(data)
 
 
+@cfg.complete(unconfigurable={"point_dataframe", "label_dataframe"})
 def render_html(
     point_dataframe,
     label_dataframe,
@@ -714,19 +717,6 @@ def render_html(
         An interactive figure with hover, pan, and zoom. This will display natively
         in a notebook, and can be saved to an HTML file via the `save` method.
     """
-    function_signature = inspect.signature(render_html)
-    function_args = locals()
-    config = ConfigManager()
-
-    for param_name, param_value in function_signature.parameters.items():
-        if param_name in ("point_dataframe", "label_dataframe"):
-            continue
-        
-        provided_value = function_args.get(param_name)
-        if provided_value is param_value.default:
-            if param_name in config:
-                function_args[param_name] = config[param_name]
-
     # Compute point scaling
     n_points = point_dataframe.shape[0]
     if point_size_scale is not None:

--- a/datamapplot/plot_rendering.py
+++ b/datamapplot/plot_rendering.py
@@ -30,7 +30,9 @@ from tempfile import NamedTemporaryFile
 
 import requests
 import re
-import inspect
+
+
+cfg = ConfigManager()
 
 
 class GoogleAPIUnreachable(Warning):
@@ -167,6 +169,15 @@ def add_glow_to_scatterplot(
         )
 
 
+@cfg.complete(
+    unconfigurable={
+        "data_map_coords",
+        "color_list",
+        "label_text",
+        "label_locations",
+        "label_cluster_sizes",
+    }
+)
 def render_plot(
     data_map_coords,
     color_list,
@@ -452,25 +463,6 @@ def render_plot(
         The axes contained within the figure that the plot is rendered to.
 
     """
-    function_signature = inspect.signature(render_plot)
-    function_args = locals()
-    config = ConfigManager()
-
-    for param_name, param_value in function_signature.parameters.items():
-        if param_name in (
-            "data_map_coords",
-            "color_list",
-            "label_text",
-            "label_locations",
-            "label_cluster_sizes",
-        ):
-            continue
-
-        provided_value = function_args.get(param_name)
-        if provided_value is param_value.default:
-            if param_name in config:
-                function_args[param_name] = config[param_name]
-
     # Create the figure
     if ax is None:
         fig, ax = plt.subplots(figsize=figsize, dpi=dpi, constrained_layout=True)

--- a/datamapplot/selection_handlers.py
+++ b/datamapplot/selection_handlers.py
@@ -1,8 +1,10 @@
 from sklearn.feature_extraction.text import ENGLISH_STOP_WORDS
 import string
-import inspect
 
 from datamapplot.config import ConfigManager
+
+
+cfg = ConfigManager()
 
 _DEFAULT_TAG_COLORS = [
     "#1f77b4", "#ff7f0e","#2ca02c","#d62728","#9467bd","#8c564b","#e377c2","#7f7f7f",
@@ -76,20 +78,8 @@ class DisplaySample(SelectionHandlerBase):
 
     """
 
+    @cfg.complete(unconfigurable={"self", "n_samples"})
     def __init__(self, n_samples=256, font_family=None, cdn_url="unpkg.com", **kwargs):
-        function_signature = inspect.signature(DisplaySample.__init__)
-        function_args = locals()
-        config = ConfigManager()
-
-        for param_name, param_value in function_signature.parameters.items():
-            if param_name in ("self", "n_samples"):
-                continue
-            
-            provided_value = function_args.get(param_name)
-            if provided_value == param_value.default:
-                if param_name in config:
-                    function_args[param_name] = config[param_name]
-
         super().__init__(
             dependencies=[
                 f"https://{cdn_url}/jquery@3.7.1/dist/jquery.min.js"
@@ -277,6 +267,7 @@ class WordCloud(SelectionHandlerBase):
 
     """
 
+    @cfg.complete(unconfigurable={"self", "width", "height", "n_words"})
     def __init__(
         self,
         n_words=256,
@@ -290,19 +281,6 @@ class WordCloud(SelectionHandlerBase):
         cdn_url="unpkg.com",
         **kwargs,
     ):
-        function_signature = inspect.signature(WordCloud.__init__)
-        function_args = locals()
-        config = ConfigManager()
-
-        for param_name, param_value in function_signature.parameters.items():
-            if param_name in ("self", "width", "height", "n_words"):
-                continue
-            
-            provided_value = function_args.get(param_name)
-            if provided_value == param_value.default:
-                if param_name in config:
-                    function_args[param_name] = config[param_name]
-        
         super().__init__(
             dependencies=[
                 f"https://{cdn_url}/d3@latest/dist/d3.min.js",
@@ -474,6 +452,7 @@ class CohereSummary(SelectionHandlerBase):
         Additional keyword arguments to pass to the SelectionHandlerBase constructor.
     """
 
+    @cfg.complete(unconfigurable={"self", "width", "n_keywords", "n_samples"})
     def __init__(
         self,
         model="command-r",
@@ -485,19 +464,6 @@ class CohereSummary(SelectionHandlerBase):
         cdn_url="unpkg.com",
         **kwargs,
     ):
-        function_signature = inspect.signature(CohereSummary.__init__)
-        function_args = locals()
-        config = ConfigManager()
-
-        for param_name, param_value in function_signature.parameters.items():
-            if param_name in ("self", "width", "n_keywords", "n_samples"):
-                continue
-            
-            provided_value = function_args.get(param_name)
-            if provided_value == param_value.default:
-                if param_name in config:
-                    function_args[param_name] = config[param_name]
-                    
         super().__init__(
             dependencies=[
                 f"https://{cdn_url}/jquery@3.7.1/dist/jquery.min.js",

--- a/datamapplot/tests/test_config.py
+++ b/datamapplot/tests/test_config.py
@@ -4,7 +4,9 @@ from pathlib import Path
 import platformdirs
 import pytest
 
+from .. import create_plot, create_interactive_plot, render_plot, render_html
 from ..config import ConfigManager, ConfigError
+from ..selection_handlers import DisplaySample, WordCloud, CohereSummary
 
 
 @pytest.fixture
@@ -88,3 +90,25 @@ def test_no_config_donttouch(the_func, config):
 
 def test_override_donttouch(the_func):
     assert the_func("A", dont_touch="poke") == ("A", (), None, "asdf", "poke", {})
+
+
+@pytest.mark.parametrize(
+    "func",
+    [
+        create_plot,
+        create_interactive_plot,
+        render_plot,
+        render_html,
+        DisplaySample.__init__,
+        WordCloud.__init__,
+        CohereSummary.__init__
+    ]
+)
+def test_has_config(func):
+    assert ConfigManager.gets_completed(func)
+
+
+def test_sanity_config_display_sample(config):
+    assert DisplaySample().font_family is None
+    config["font_family"] = "Roboto"
+    assert DisplaySample().font_family == "Roboto"

--- a/datamapplot/tests/test_config.py
+++ b/datamapplot/tests/test_config.py
@@ -1,0 +1,90 @@
+from copy import copy
+import inspect as ins
+from pathlib import Path
+import platformdirs
+import pytest
+
+from ..config import ConfigManager, ConfigError
+
+
+@pytest.fixture
+def no_change_to_config_file():
+    cfgmgr = ConfigManager()
+    assert cfgmgr._config_file.is_file()
+    contents_before = cfgmgr._config_file.read_bytes()
+    try:
+        yield None
+    finally:
+        contents_after = cfgmgr._config_file.read_bytes()
+        if contents_after != contents_before:
+            cfgmgr._config_file.write_bytes(contents_before)
+            pytest.fail(
+                "Unit test was supposed not to change the configuration file, "
+                "yet it did."
+            )
+
+
+def test_tweak_config_sanity(no_change_to_config_file):
+    cfgmgr = ConfigManager()
+    cfgmgr["asdf"] = "qwer"
+
+
+@pytest.fixture
+def config(no_change_to_config_file):
+    config = ConfigManager()
+    orig = copy(config._config)
+    yield config
+    config._config = orig
+
+
+@pytest.fixture
+def the_func(config):
+    for name in ["a", "args", "b", "c", "dont_touch", "kwargs"]:
+        assert name not in config
+
+    @config.complete({"dont_touch"})
+    def _the_func(a, *args, b=None, c="asdf", dont_touch="nope", **kwargs):
+        return a, args, b, c, dont_touch, kwargs
+    return _the_func
+
+
+def test_no_config_args(the_func, config):
+    config["args"] = ("heck", "no")
+    with pytest.raises(ConfigError):
+        the_func("A")
+
+
+def test_no_config_kwargs(the_func, config):
+    config["kwargs"] = {"heck": "no"}
+    with pytest.raises(ConfigError):
+        the_func("A")
+
+
+def test_config_positional_useless(the_func, config):
+    config["a"] = "how would that even work?"  # Can never reach.
+    assert the_func("A") == ("A", (), None, "asdf", "nope", {})
+
+
+def test_fetch_b_config(the_func, config):
+    config["b"] = 98
+    assert the_func("A") == ("A", (), 98, "asdf", "nope", {})
+
+
+def test_override_configed_b(the_func, config):
+    config["b"] = 98
+    assert the_func("A", "B", b=3) == ("A", ("B",), 3, "asdf", "nope", {})
+
+
+def test_nonconfiged_c(the_func, config):
+    config["b"] = 98
+    assert the_func("A", c="qwer") == ("A", (), 98, "qwer", "nope", {})
+
+
+def test_no_config_donttouch(the_func, config):
+    config["dont_touch"] = "this mustn't work"
+    with pytest.raises(ConfigError):
+        the_func("A")
+
+
+def test_override_donttouch(the_func):
+    assert the_func("A", dont_touch="poke") == ("A", (), None, "asdf", "poke", {})


### PR DESCRIPTION
The alternative approach proposed here leverages function decorators to supply a user's choice of default values for the many parameters of the main entry points to DataMapPlot. While a bit more complicated than the former approach, this one avoids the awkward playing with the `locals()` dictionary, and ensures that strictly positional parameters to configuration-completed functions can never be set through the configuration file.