### PR TITLE
Fix font cache dir name

### DIFF
--- a/datamapplot/interactive_rendering.py
+++ b/datamapplot/interactive_rendering.py
@@ -1032,7 +1032,7 @@ def render_html(
 
         if offline_mode_font_data_file is None:
             data_directory = platformdirs.user_data_dir("datamapplot")
-            offline_mode_font_data_file = Path(data_directory) / "datamapplot_font_encoded.json"
+            offline_mode_font_data_file = Path(data_directory) / "datamapplot_fonts_encoded.json"
             if not offline_mode_font_data_file.is_file():
                 offline_mode_caching.cache_fonts()
 


### PR DESCRIPTION
Make the font cache dir name match the [download script](https://github.com/TutteInstitute/datamapplot/blob/main/datamapplot/offline_mode_caching.py#L48). Alternatively we could change the download script to match the existing dir name.