### PR TITLE
Cap the version of dask in test environment creation

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -80,7 +80,7 @@ stages:
 
         - task: Cache@2
           inputs:
-            key: 'pip | "$(Build.SourcesDirectory)/test-requirements.txt"'
+            key: 'pip | "$(Build.SourcesDirectory)/test-requirements.txt" | "$(Build.SourcesDirectory)/setup.cfg"'
             restoreKeys: |
               pip |
             path: $(PIP_CACHE_DIR)
@@ -97,6 +97,17 @@ stages:
         - script: |
             pip install -e .
           displayName: 'Install local package'
+
+        # Debugging import datashader
+        - script: |
+            echo "Installed packages:"
+            pip list
+            echo "\nDask information:"
+            python -c "import dask; print('Dask version:', dask.__version__)"
+            python -c "import dask.dataframe; print('Dask DataFrame path:', dask.dataframe.__file__)"
+            echo "\nDatashader information:"
+            python -c "import datashader; print('Datashader version:', datashader.__version__)"
+          displayName: 'Debug dependency versions'
 
         - script: |
             export CI=true

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -98,16 +98,16 @@ stages:
             pip install -e .
           displayName: 'Install local package'
 
-        # Debugging import datashader
-        - script: |
-            echo "Installed packages:"
-            pip list
-            echo "\nDask information:"
-            python -c "import dask; print('Dask version:', dask.__version__)"
-            python -c "import dask.dataframe; print('Dask DataFrame path:', dask.dataframe.__file__)"
-            echo "\nDatashader information:"
-            python -c "import datashader; print('Datashader version:', datashader.__version__)"
-          displayName: 'Debug dependency versions'
+        # # Debugging import datashader
+        # - script: |
+        #     echo "Installed packages:"
+        #     pip list
+        #     echo "Dask information:"
+        #     python -c "import dask; print('Dask version:', dask.__version__)"
+        #     python -c "import dask.dataframe; print('Dask DataFrame path:', dask.dataframe.__file__)"
+        #     echo "Datashader information:"
+        #     python -c "import datashader; print('Datashader version:', datashader.__version__)"
+        #   displayName: 'Debug dependency versions'
 
         - script: |
             export CI=true

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,5 +1,5 @@
 coveralls
-dask[dataframe]<2025.0.1
+dask[dataframe]<2025.0.1 # temporarily cap. 2025.0.1 is incompatible with datashader
 pytest
 pytest-azurepipelines
 pytest-cov

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,5 +1,5 @@
 coveralls
-dask[dataframe]<2025.0.0
+dask[dataframe]<2025.0.1
 pytest
 pytest-azurepipelines
 pytest-cov

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,5 +1,5 @@
 coveralls
-dask[dataframe]
+dask[dataframe]<2025.0.0
 pytest
 pytest-azurepipelines
 pytest-cov


### PR DESCRIPTION
The latest version of dask  (2025.0.1) is not compatible with datashader (see below). Cap the version of dask in the `test-requirements.txt` for now. 

```
datamapplot/__init__.py:1: in <module>
    from datamapplot.create_plots import create_plot, create_interactive_plot
datamapplot/create_plots.py:15: in <module>
    from datamapplot.plot_rendering import render_plot
datamapplot/plot_rendering.py:4: in <module>
    import datashader as ds
../../../hostedtoolcache/Python/3.10.16/x64/lib/python3.10/site-packages/datashader/__init__.py:14: in <module>
    from . import data_libraries                             # noqa (API import)
../../../hostedtoolcache/Python/3.10.16/x64/lib/python3.10/site-packages/datashader/data_libraries/__init__.py:5: in <module>
    from . import dask    # noqa (API import)
../../../hostedtoolcache/Python/3.10.16/x64/lib/python3.10/site-packages/datashader/data_libraries/dask.py:55: in <module>
    bypixel.pipeline.register(dd.core.DataFrame)(dask_pipeline)
E   AttributeError: module 'dask.dataframe.core' has no attribute 'DataFrame'

```