### PR TITLE
table of contents added

### DIFF
--- a/datamapplot/create_plots.py
+++ b/datamapplot/create_plots.py
@@ -357,6 +357,7 @@ def create_interactive_plot(
     polygon_alpha=0.1,
     cvd_safer=False,
     jupyterhub_api_token=None,
+    enable_table_of_contents=False,
     **render_html_kwds,
 ):
     """
@@ -462,9 +463,12 @@ def create_interactive_plot(
         This will override any provided cmap and use a CVD safer palette instead.
 
     jupyterhub_api_token: str or None (optional, default=None)
-        The JupyterHub API token to use when rendering the plot inline in a notebook via jupyterhub. 
+        The JupyterHub API token to use when rendering the plot inline in a notebook via jupyterhub.
         This should not be necessary for most users, but can be useful in some environments where
         the default token is not available.
+
+    enable_table_of_contents: bool (optional, default=False)
+        Whether to build and display a table of contents with the label heirarchy.
 
     **render_html_kwds:
         All other keyword arguments will be passed through the `render_html` function. Please
@@ -484,6 +488,31 @@ def create_interactive_plot(
                 "size": [np.power(data_map_coords.shape[0], 0.25)],
             }
         )
+    elif enable_table_of_contents:
+        # This method of allowing label_text_and_polygon_dataframes to edit parents is unsavory,
+        # but means that the function has the same return statement each time and we can still use
+        # list comprehension.
+        #
+        parents = [[]]
+        label_lists = [
+            label_text_and_polygon_dataframes(
+                labels,
+                data_map_coords,
+                noise_label=noise_label,
+                use_medoids=use_medoids,
+                cluster_polygons=cluster_boundary_polygons,
+                alpha=polygon_alpha,
+                include_related_points=True,
+                parents=parents,
+            )
+            for labels in label_layers[::-1]
+        ]
+
+        # Mark the lowest layer labels so they can be displayed differently in the table of contents.
+        #
+        label_lists[-1]["lowest_layer"] = True
+
+        label_dataframe = pd.concat(label_lists)
     else:
         label_dataframe = pd.concat(
             [
@@ -499,6 +528,11 @@ def create_interactive_plot(
             ]
         )
 
+    # Split out the noise labels (placeholders for table of contents) so we can make color palettes.
+    #
+    noise_label_dataframe = label_dataframe[label_dataframe["label"] == noise_label]
+    label_dataframe = label_dataframe[label_dataframe["label"] != noise_label]
+
     if cvd_safer:
         cmap = colorcet.cm.CET_C2s
     if label_color_map is None:
@@ -508,7 +542,7 @@ def create_interactive_plot(
                 label_dataframe[["x", "y"]].values,
                 hue_shift=palette_hue_shift,
                 radius_weight_power=palette_hue_radius_dependence,
-                theta_range=palette_theta_range
+                theta_range=palette_theta_range,
             )
         else:
             palette = palette_from_cmap_and_datamap(
@@ -516,7 +550,7 @@ def create_interactive_plot(
                 data_map_coords,
                 label_dataframe[["x", "y"]].values,
                 radius_weight_power=palette_hue_radius_dependence,
-                theta_range=palette_theta_range
+                theta_range=palette_theta_range,
             )
         if not darkmode:
             text_palette = np.asarray(
@@ -574,6 +608,9 @@ def create_interactive_plot(
     label_dataframe["label"] = label_dataframe.label.map(
         lambda x: textwrap.fill(x, width=label_wrap_width, break_long_words=False)
     )
+
+    # Recombine noise label placeholders.
+    label_dataframe = pd.concat([label_dataframe, noise_label_dataframe])
 
     point_dataframe = pd.DataFrame(
         {
@@ -633,7 +670,10 @@ def create_interactive_plot(
         noise_color=noise_color,
         label_layers=label_layers,
         cluster_colormap=color_map | {noise_label:noise_color},
+        enable_table_of_contents=enable_table_of_contents,
         **render_html_kwds,
     )
 
-    return InteractiveFigure(html_str, width=width, height=height, api_token=jupyterhub_api_token)
+    return InteractiveFigure(
+        html_str, width=width, height=height, api_token=jupyterhub_api_token
+    )

--- a/datamapplot/deckgl_template.html
+++ b/datamapplot/deckgl_template.html
@@ -641,7 +641,7 @@
                         toc.highlightElements(visible)
                     };
                 };
-            }, 250);
+            }, 50);
             
             datamap.deckgl.setProps({
                 onViewStateChange: debouncedViewStateChange,

--- a/datamapplot/deckgl_template.html
+++ b/datamapplot/deckgl_template.html
@@ -120,7 +120,14 @@
         width: fit-content;
       }
       {%- endif %}
-      {%- if custom_css %}
+      {%- if table_of_contents %}
+        /* Highlight styling for table of contents */
+        .highlighted {
+            background-color: {{toc_highlight_color}};
+            border-radius: 2px;
+        }
+      {%- endif %}
+       {%- if custom_css %}
       {{custom_css}}
       {%- endif %}
     </style>
@@ -157,6 +164,10 @@
           {% if search %}
           <div id="search-container" class="container-box">
             <input autocomplete="off" type="search" id="text-search" placeholder="🔍" />
+          </div>
+          {% endif %}
+          {% if table_of_contents %}
+          <div id="table-of-contents" class="container-box">
           </div>
           {% endif %}
         </div>
@@ -565,7 +576,14 @@
           {% else -%}
           const labelData = data[0].chunkData;
           {% endif -%}
-          datamap.addLabels(labelData, {
+          datamap.labelData = labelData;
+          // Only build labels where we have a position.
+          datamap.addLabels(
+            {%- if enable_table_of_contents -%}
+            labelData.filter((d) => {return !d.id.endsWith('-1')})
+            {%- else -%}
+            labelData
+            {%- endif -%}, {
             labelTextColor: {{label_text_color}},
             textMinPixelSize: {{text_min_pixel_size}},
             textMaxPixelSize: {{text_max_pixel_size}},
@@ -576,10 +594,61 @@
             fontWeight: {{font_weight}},
             lineSpacing: {{line_spacing}},
             textCollisionSizeScale: {{text_collision_size_scale}},
+            pickable: true,
           });
 
+          {% if table_of_contents %}
+            const tocContainer = document.querySelector('#table-of-contents');
+            
+            {% if table_of_contents_on_click %}
+            const toc = new TableOfContents(
+                tocContainer,
+                datamap,
+                true,
+                "{{table_of_contents_button_icon}}"                
+            );
+              
+            // Set up the table of contents button behaviour.
+            toc.container.querySelectorAll('.toc-btn').forEach(button => {
+                button.addEventListener('click', function() {
+                    var label = datamap.labelData.find(l => {
+                      return l.id === this.dataset.labelId
+                    })
+                    {{table_of_contents_on_click}}
+                    // console.log(
+                    //     label.points[0].map(x=>datamap.metaData.hover_text[x])
+                    // );
+                });
+            });
+            {% else %}
+            const toc = new TableOfContents(
+                tocContainer,
+                datamap,
+                false,
+                null                
+            );
+            {% endif -%}
+            
+            
+            const onViewStateChange = ({viewState, interactionState}) => {
+                const userIsInteracting = Object.values(interactionState).every(Boolean);
+                if (!userIsInteracting) {
+                    const visible = getVisibleTextData(viewState)
+                    if (visible) {
+                        toc.highlightElements(visible)
+                    };
+                };
+            };
+            
+            datamap.deckgl.setProps({
+                onViewStateChange: onViewStateChange,
+            });
+
+          {% endif %}
           {% if cluster_boundary_polygons %}
-          datamap.addBoundaries(labelData, {
+          datamap.addBoundaries(labelData.filter((d) => {
+                return d.polygon
+            }), {
             clusterBoundaryLineWidth: {{cluster_boundary_line_width}},
           });
           {% endif %}
@@ -722,6 +791,46 @@
     }
     {% endif -%}
 
+    {% if table_of_contents %}
+    function isBoundsVisible({bounds, viewState}) {
+        const {width, height, longitude, latitude, zoom} = viewState;
+    
+        const Viewport = new deck.WebMercatorViewport({
+            width,
+            height,
+            longitude,
+            latitude,
+            zoom,
+        })
+    
+        const viewBounds = [
+            [0,0],
+            [width, height],
+        ];
+    
+        const minBounds = Viewport.project([bounds[0], bounds[2]]);
+        const maxBounds = Viewport.project([bounds[1], bounds[3]]);
+    
+        return (
+            ((minBounds[0] >= 0 && minBounds[0] <= width) || (maxBounds[0] >= 0 && maxBounds[0] <= width)) &&
+            ((minBounds[1] >= 0 && minBounds[1] <= height) || (maxBounds[1] >= 0 && maxBounds[1] <= height))
+        );
+    };
+          
+    function getVisibleTextData(viewState) {
+        if (datamap.labelData) {
+            const visibleData = datamap.labelData.filter((d) => {
+                return isBoundsVisible({
+                    bounds: d.bounds,
+                    viewState: viewState,
+                });
+            });
+            return visibleData;
+        };
+    };
+    
+    {% endif %}
+      
     {%- if background_image -%}
     datamap.addBackgroundImage("{{background_image}}", {{background_image_bounds}});
     {%- endif %}

--- a/datamapplot/deckgl_template.html
+++ b/datamapplot/deckgl_template.html
@@ -120,13 +120,6 @@
         width: fit-content;
       }
       {%- endif %}
-      {%- if table_of_contents %}
-        /* Highlight styling for table of contents */
-        .highlighted {
-            background-color: {{toc_highlight_color}};
-            border-radius: 2px;
-        }
-      {%- endif %}
        {%- if custom_css %}
       {{custom_css}}
       {%- endif %}
@@ -166,7 +159,7 @@
             <input autocomplete="off" type="search" id="text-search" placeholder="🔍" />
           </div>
           {% endif %}
-          {% if table_of_contents %}
+          {% if enable_table_of_contents %}
           <div id="table-of-contents" class="container-box">
           </div>
           {% endif %}
@@ -580,7 +573,7 @@
           // Only build labels where we have a position.
           datamap.addLabels(
             {%- if enable_table_of_contents -%}
-            labelData.filter((d) => {return !d.id.endsWith('-1')})
+            labelData.filter((d) => {return !(d.id.endsWith('-1'))})
             {%- else -%}
             labelData
             {%- endif -%}, {
@@ -597,7 +590,7 @@
             pickable: true,
           });
 
-          {% if table_of_contents %}
+          {% if enable_table_of_contents %}
             const tocContainer = document.querySelector('#table-of-contents');
             
             {% if table_of_contents_on_click %}
@@ -629,8 +622,18 @@
             );
             {% endif -%}
             
-            
-            const onViewStateChange = ({viewState, interactionState}) => {
+            function debounce(func, wait) {
+                let timeout;
+                return function executedFunction(...args) {
+                    const later = () => {
+                        clearTimeout(timeout);
+                        func(...args);
+                    };
+                    clearTimeout(timeout);
+                    timeout=setTimeout(later, wait);
+                };
+            }
+            const debouncedViewStateChange = debounce(({viewState, interactionState}) => {
                 const userIsInteracting = Object.values(interactionState).every(Boolean);
                 if (!userIsInteracting) {
                     const visible = getVisibleTextData(viewState)
@@ -638,10 +641,10 @@
                         toc.highlightElements(visible)
                     };
                 };
-            };
+            }, 250);
             
             datamap.deckgl.setProps({
-                onViewStateChange: onViewStateChange,
+                onViewStateChange: debouncedViewStateChange,
             });
 
           {% endif %}
@@ -791,7 +794,7 @@
     }
     {% endif -%}
 
-    {% if table_of_contents %}
+    {% if enable_table_of_contents %}
     function isBoundsVisible({bounds, viewState}) {
         const {width, height, longitude, latitude, zoom} = viewState;
     

--- a/datamapplot/interactive_rendering.py
+++ b/datamapplot/interactive_rendering.py
@@ -982,7 +982,7 @@ def label_text_and_polygon_dataframes(
         for parent_mask in parent_masks:
             cluster_mask = unlabeled_mask & parent_mask
 
-            if np.any(cluster_mask):
+            if np.sum(cluster_mask) > 2:
                 cluster_points = data_map_coords[cluster_mask]
                 label_locations.append(cluster_points.mean(axis=0))
                 cluster_sizes.append(None)

--- a/datamapplot/interactive_rendering.py
+++ b/datamapplot/interactive_rendering.py
@@ -953,7 +953,7 @@ def label_text_and_polygon_dataframes(
             if len(parents[0]):
                 # Get the provenance (cluster membership at different heirarchical layers).
                 # This should be consistent.(??)
-                p = list(
+                p = ["base"] + list(
                     np.median(parents[0][:, cluster_mask], axis=1)
                     .astype(int)
                     .astype(str)
@@ -961,8 +961,8 @@ def label_text_and_polygon_dataframes(
                 label_ids.append("_".join(p))
                 parent_ids.append("_".join(p[:-1]))
             else:
-                label_ids.append(str(i))
-                parent_ids.append(None)
+                label_ids.append(f"base_{i}")
+                parent_ids.append("base")
 
     if parents is not None:
         # do the same for unlabeled points, noting that not all unlabeled
@@ -994,7 +994,7 @@ def label_text_and_polygon_dataframes(
                 if len(parents[0]):
                     # Get the provenance.
                     # This should be consistent.(??)
-                    p = list(
+                    p = ["base"] + list(
                         np.median(parents[0][:, cluster_mask], axis=1)
                         .astype(int)
                         .astype(str)
@@ -1002,8 +1002,8 @@ def label_text_and_polygon_dataframes(
                     label_ids.append("_".join(p))
                     parent_ids.append("_".join(p[:-1]))
                 else:
-                    label_ids.append(str(i))
-                    parent_ids.append(None)
+                    label_ids.append("base_-1")
+                    parent_ids.append("base")
 
     if parents is not None:
         # parents is mutable, add on the currend cluster idx_vector.

--- a/datamapplot/static/css/table_of_contents_style.css
+++ b/datamapplot/static/css/table_of_contents_style.css
@@ -1,0 +1,149 @@
+#table-of-contents {
+    display: block;
+    max-height: 48vh;
+    max-width: 30vw;
+    overflow: auto;
+}
+
+/* Add some padding to prevent scroll bar from overlapping content */
+#table-of-contents > .nested {
+    display: block;
+    padding-right: 10px;
+}
+
+.toc-container {
+    display: flex;
+    flex-direction: column;
+}
+
+.toc-header {
+    padding: 8px;
+    border-bottom: 1px solid #ddd;
+    margin-bottom: 8px;
+}
+
+.nested {
+    display: none;
+    margin-left: 20px;
+    list-style-type: none;
+    padding-inline-start: 10px;
+}
+
+.nested.active {
+    display: block;
+}
+
+/* Optional: Style the scrollbar for webkit browsers */
+#table-of-contents::-webkit-scrollbar {
+    width: 8px;
+}
+
+#table-of-contents::-webkit-scrollbar-track {
+    background: #f1f1f1;
+}
+
+#table-of-contents::-webkit-scrollbar-thumb {
+    background: #888;
+    border-radius: 4px;
+}
+
+#table-of-contents::-webkit-scrollbar-thumb:hover {
+    background: #555;
+}
+
+.caret {
+    cursor: pointer;
+    user-select: none;
+    padding: 2px 4px;
+    border-radius: 3px;
+    transition: background-color 0.3s ease;
+}
+
+.caret::before {
+    content: "\25B6";
+    color: black;
+    display: inline-block;
+    margin-right: 6px;
+}
+
+.caret-down::before {
+    transform: rotate(90deg);
+}
+
+.caret.unlabeled {
+    color: #666;
+    font-style: italic;
+}
+
+.caret.unlabeled::before {
+    color: #666;
+}
+
+.bullet {
+    cursor: pointer;
+    user-select: none;
+    padding: 2px 4px;
+    border-radius: 3px;
+    transition: background-color 0.3s ease;
+}
+
+.bullet::before {
+    content: "\25CF";
+    color: black;
+    display: inline-block;
+    margin-right: 6px;
+}
+
+.bullet.unlabeled {
+    color: #666;
+    font-style: italic;
+}
+
+.bullet.unlabeled::before {
+    color: #666;
+}
+
+
+li {
+    list-style-type: none;
+    margin: 5px 0;
+}
+
+/* table of contents buttons */
+.toc-btn {
+    border: none; /* Remove borders */
+    color: white; /* White text */
+    padding: 2px 4px;
+    border-radius: 5px;
+    cursor: pointer; /* Mouse pointer on hover */
+}
+
+/* Darker background on mouse-over */
+.toc-btn:hover {
+    background-color: RoyalBlue;
+}
+
+/* table of contents labels */
+.toc-label {
+    border: none; /* Remove borders */
+    padding: 2px 4px;
+    border-radius: 5px;
+    cursor: pointer; /* Mouse pointer on hover */
+}
+
+/* Darker background on mouse-over */
+.toc-label:hover {
+    text-decoration: underline;
+}
+
+.expand-all-btn {
+    padding: 4px 8px;
+    cursor: pointer;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    background: #f8f8f8;
+}
+
+.expand-all-btn:hover {
+    text-decoration: underline;
+}

--- a/datamapplot/static/css/table_of_contents_style.css
+++ b/datamapplot/static/css/table_of_contents_style.css
@@ -61,7 +61,6 @@
 
 .caret::before {
     content: "\25B6";
-    color: black;
     display: inline-block;
     margin-right: 6px;
 }
@@ -71,12 +70,11 @@
 }
 
 .caret.unlabeled {
-    color: #666;
-    font-style: italic;
+    color: #888;
 }
 
 .caret.unlabeled::before {
-    color: #666;
+    color: #888;
 }
 
 .bullet {
@@ -89,20 +87,17 @@
 
 .bullet::before {
     content: "\25CF";
-    color: black;
     display: inline-block;
     margin-right: 6px;
 }
 
 .bullet.unlabeled {
-    color: #666;
-    font-style: italic;
+    color: #888;
 }
 
 .bullet.unlabeled::before {
-    color: #666;
+    color: #888;
 }
-
 
 li {
     list-style-type: none;
@@ -126,8 +121,6 @@ li {
 /* table of contents labels */
 .toc-label {
     border: none; /* Remove borders */
-    padding: 2px 4px;
-    border-radius: 5px;
     cursor: pointer; /* Mouse pointer on hover */
 }
 
@@ -146,4 +139,9 @@ li {
 
 .expand-all-btn:hover {
     text-decoration: underline;
+}
+
+/* Highlight styling */
+.highlighted {
+    -webkit-text-stroke: 2px #4169E1;
 }

--- a/datamapplot/static/css/table_of_contents_style.css
+++ b/datamapplot/static/css/table_of_contents_style.css
@@ -1,10 +1,22 @@
 #table-of-contents {
     display: block;
-    max-height: 48vh;
-    max-width: 30vw;
-    overflow: auto;
+    height: fit-content;
+    width: fit-content;
 }
 
+#toc-body {
+    overflow-y: auto;
+    display: flex;
+    flex-direction: column;
+    max-height: 42vh;
+    max-width: 30vw;
+}
+
+/* Add some padding to prevent scroll bar from overlapping content */
+#toc-body > .nested {
+    display: block;
+    padding-right: 10px;
+}
 /* Add some padding to prevent scroll bar from overlapping content */
 #table-of-contents > .nested {
     display: block;
@@ -20,6 +32,10 @@
     padding: 8px;
     border-bottom: 1px solid #ddd;
     margin-bottom: 8px;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    flex-direction: row;
 }
 
 .nested {
@@ -38,16 +54,14 @@
     width: 8px;
 }
 
-#table-of-contents::-webkit-scrollbar-track {
+#toc-body::-webkit-scrollbar-track {
     background: #f1f1f1;
 }
-
-#table-of-contents::-webkit-scrollbar-thumb {
+#toc-body::-webkit-scrollbar-thumb {
     background: #888;
     border-radius: 4px;
 }
-
-#table-of-contents::-webkit-scrollbar-thumb:hover {
+#toc-body::-webkit-scrollbar-thumb:hover {
     background: #555;
 }
 
@@ -56,7 +70,8 @@
     user-select: none;
     padding: 2px 4px;
     border-radius: 3px;
-    transition: background-color 0.3s ease;
+    opacity: 0.4;
+    transition: opacity 0.3s ease;
 }
 
 .caret::before {
@@ -69,12 +84,13 @@
     transform: rotate(90deg);
 }
 
-.caret.unlabeled {
+/* .caret.unlabeled {
     color: #888;
-}
+} */
 
 .caret.unlabeled::before {
-    color: #888;
+    content: "\25b7";
+    /* color: #888; */
 }
 
 .bullet {
@@ -82,7 +98,8 @@
     user-select: none;
     padding: 2px 4px;
     border-radius: 3px;
-    transition: background-color 0.3s ease;
+    opacity: 0.4;
+    transition: opacity 0.3s ease;
 }
 
 .bullet::before {
@@ -91,12 +108,13 @@
     margin-right: 6px;
 }
 
-.bullet.unlabeled {
+/* .bullet.unlabeled {
     color: #888;
-}
+} */
 
 .bullet.unlabeled::before {
-    color: #888;
+    content: "\25CB";
+    /* color: #888; */
 }
 
 li {
@@ -132,9 +150,10 @@ li {
 .expand-all-btn {
     padding: 4px 8px;
     cursor: pointer;
-    border: 1px solid #ccc;
-    border-radius: 4px;
-    background: #f8f8f8;
+    border: none;
+    border-radius: 8px;
+    background: #3ba5e7;
+    color: white;
 }
 
 .expand-all-btn:hover {
@@ -143,5 +162,6 @@ li {
 
 /* Highlight styling */
 .highlighted {
-    -webkit-text-stroke: 2px #4169E1;
+    opacity: 1.0;
+    transition: opacity 0.3s ease;
 }

--- a/datamapplot/static/js/datamap.js
+++ b/datamapplot/static/js/datamap.js
@@ -1,5 +1,5 @@
 
-LAYER_ORDER = ['imageLayer', 'dataPointLayer', 'boundaryLayer', 'LabelLayer'];
+LAYER_ORDER = ['imageLayer', 'dataPointLayer', 'boundaryLayer', 'labelLayer'];
 
 function getLayerIndex(object) {
   return LAYER_ORDER.indexOf(object.id);
@@ -65,6 +65,7 @@ class DataMap {
     this.searchItemId = searchItemId;
     this.lassoSelectionItemId = lassoSelectionItemId;
     this.pointData = null;
+    this.labelData = null;
     this.metaData = null;
     this.layers = [];
     const { viewportWidth, viewportHeight } = getInitialViewportSize();
@@ -183,7 +184,9 @@ class DataMap {
     fontWeight = 900,
     lineSpacing = 0.95,
     textCollisionSizeScale = 3.0,
+    pickable = true,
   }) {
+    
     const numLabels = labelData.length;
     this.labelTextColor = labelTextColor;
     this.textMinPixelSize = textMinPixelSize;
@@ -199,9 +202,10 @@ class DataMap {
     waitForFont(this.fontFamily);
 
     this.labelLayer = new deck.TextLayer({
-      id: 'LabelLayer',
+      id: 'labelLayer',
+      // Only add labels with valid x positions.
       data: labelData,
-      pickable: false,
+      pickable: pickable,
       getPosition: d => [d.x, d.y],
       getText: d => d.label,
       getColor: this.labelTextColor,

--- a/datamapplot/static/js/table_of_contents.js
+++ b/datamapplot/static/js/table_of_contents.js
@@ -105,14 +105,11 @@ class TableOfContents {
             latitude: dataCenter[1],
             longitude: dataCenter[0],
             zoom: zoomLevel,
+            transitionDuration: 1000,
         };
         this.datamap.deckgl.setProps({
-            viewState: viewState,
+            initialViewState: {...viewState},
         });
-        // highlightElements(getVisibleTextData(viewState)) - For some reason this won't work, but would be ideal.
-        const labelElements = this.elements.filter((label) => {return label.id.startsWith(labelId)});
-    
-        this.highlightElements(labelElements);
     }
 
     highlightElements(elements) {
@@ -168,15 +165,15 @@ class TableOfContents {
                 const nestedList = getNextSibling(caret, '.nested');
                 if (isExpanded) {
                     // Collapse all
-                    caret.classList.toggle('caret-down');
+                    caret.classList.remove('caret-down');
                     if (nestedList) {
-                        nestedList.classList.toggle('active');
+                        nestedList.classList.remove('active');
                     }
                 } else {
                     // Expand all
-                    caret.classList.toggle('caret-down');
+                    caret.classList.add('caret-down');
                     if (nestedList) {
-                        nestedList.classList.toggle('active');
+                        nestedList.classList.add('active');
                     }
                 }
             });

--- a/datamapplot/static/js/table_of_contents.js
+++ b/datamapplot/static/js/table_of_contents.js
@@ -32,8 +32,12 @@ class TableOfContents {
         this.parentChildMap = this.buildParentChildMap();
         
         this.container.innerHTML = `
-            <button class="expand-all-btn" data-expanded="false">Expand All</button>
+            <div class="toc-header">
+                <h3>Topic Tree</h3><button class="expand-all-btn" data-expanded="false">Expand All</button>
+            </div>
+            <div id="toc-body">
             ${this.buildTreeHtml(buttons, icon)}
+            </div>
         `;
     
         this.setupCaretHandlers();
@@ -49,24 +53,24 @@ class TableOfContents {
         // First, handle elements with actual parents
         this.elements.forEach(element => {
             const parentId = element.parent;
-            if (parentId) {
-                if (!parentChildMap.has(parentId)) {
-                    parentChildMap.set(parentId, []);
-                }
-                parentChildMap.get(parentId).push(element);
-            } else {
-                // Handle root level elements
-                if (!parentChildMap.has(null)) {
-                    parentChildMap.set(null, []);
-                }
-                parentChildMap.get(null).push(element);
+            // if (parentId === 'base') {
+            if (!parentChildMap.has(parentId)) {
+                parentChildMap.set(parentId, []);
             }
+            parentChildMap.get(parentId).push(element);
+            // } else {
+            //     // Handle root level elements
+            //     if (!parentChildMap.has('base')) {
+            //         parentChildMap.set('base', []);
+            //     }
+            //     parentChildMap.get('base').push(element);
+            // }
         });
     
         return parentChildMap;
     }
 
-    buildTreeHtml(buttons, icon, parentId = null) {
+    buildTreeHtml(buttons, icon, parentId = 'base') {
         const children = this.parentChildMap.get(parentId) || [];
         
         if (children.length === 0) return '';

--- a/datamapplot/static/js/table_of_contents.js
+++ b/datamapplot/static/js/table_of_contents.js
@@ -1,0 +1,189 @@
+// Helper to get the next nested list out of the table of contents.
+var getNextSibling = function (elem, selector) {
+    // Get the next sibling element
+    var sibling = elem.nextElementSibling;
+
+    // If there's no selector, return the first sibling
+    if (!selector) return sibling;
+
+    // If the sibling matches our selector, use it
+    // If not, jump to the next sibling and continue the loop
+    while (sibling) {
+        if (sibling.matches(selector)) return sibling;
+        sibling = sibling.nextElementSibling
+    }
+};
+
+function formatTocButtonHtml(icon, labelId) {
+    return `<button class="toc-btn" data-label-id="${labelId}">${icon}</button>`;
+}
+
+class TableOfContents {
+    constructor(
+        tocContainer,
+        datamap,
+        buttons,
+        icon,
+    ) {
+        this.container = tocContainer;
+        this.datamap = datamap;
+        this.elements = datamap.labelData;
+        this.rootLayerNo = Math.max(...datamap.labelData.map(e => e.layer_no));
+        this.parentChildMap = this.buildParentChildMap();
+        
+        this.container.innerHTML = `
+            <button class="expand-all-btn" data-expanded="false">Expand All</button>
+            ${this.buildTreeHtml(buttons, icon)}
+        `;
+    
+        this.setupCaretHandlers();
+        this.setupLabelHandlers(datamap);
+        this.setupExpandAllHandler();
+        this.highlightElements(this.elements);
+    }
+    
+
+    buildParentChildMap() {
+        const parentChildMap = new Map();
+        
+        // First, handle elements with actual parents
+        this.elements.forEach(element => {
+            const parentId = element.parent;
+            if (parentId) {
+                if (!parentChildMap.has(parentId)) {
+                    parentChildMap.set(parentId, []);
+                }
+                parentChildMap.get(parentId).push(element);
+            } else {
+                // Handle root level elements
+                if (!parentChildMap.has(null)) {
+                    parentChildMap.set(null, []);
+                }
+                parentChildMap.get(null).push(element);
+            }
+        });
+    
+        return parentChildMap;
+    }
+
+    buildTreeHtml(buttons, icon, parentId = null) {
+        const children = this.parentChildMap.get(parentId) || [];
+        
+        if (children.length === 0) return '';
+    //.map(x=>datamap.pointData[x]
+        return `
+            <ul class="nested">
+                ${children.map(label => `
+                    <li>
+                        <span class="${label.lowest_layer ? 'bullet' : 'caret'} ${label.id.endsWith('-1') ? 'unlabeled' : ''}" data-element-id="${label.id}">
+                        </span>${buttons ? formatTocButtonHtml(icon, label.id) : ''}
+                        <span class="toc-label" data-bounds="${JSON.stringify(label.bounds)}" data-label-id="${label.id}">
+                            ${label.label || label.id}
+                        </span>
+                        ${this.buildTreeHtml(buttons, icon, label.id)}
+                    </li>
+                `).join('')}
+            </ul>
+        `;
+    }
+
+    setupLabelHandlers(datamap) {
+        var toc = this
+        this.container.querySelectorAll('.toc-label').forEach(button => {
+            button.addEventListener('click', function() {
+                const bounds = JSON.parse(this.dataset.bounds);
+                const labelId = this.dataset.labelId;
+                toc.zoomToLabelBounds(bounds, labelId);
+            });
+        });
+    }
+
+    zoomToLabelBounds(bounds, labelId) {
+        const { viewportWidth, viewportHeight } = getInitialViewportSize();
+        const { zoomLevel, dataCenter } = calculateZoomLevel(bounds, viewportWidth, viewportHeight);
+        const viewState = {
+            latitude: dataCenter[1],
+            longitude: dataCenter[0],
+            zoom: zoomLevel,
+        };
+        this.datamap.deckgl.setProps({
+            viewState: viewState,
+        });
+        // highlightElements(getVisibleTextData(viewState)) - For some reason this won't work, but would be ideal.
+        const labelElements = this.elements.filter((label) => {return label.id.startsWith(labelId)});
+    
+        this.highlightElements(labelElements);
+    }
+
+    highlightElements(elements) {
+        this.container.querySelectorAll('.highlighted').forEach(element => {
+            element.classList.remove('highlighted');
+        });
+        
+        elements.forEach(element => {
+            this.highlightElementAndParents(element);
+        });
+    }
+
+    highlightElementAndParents(element) {
+        const elementSpan = this.container.querySelector(`[data-element-id="${element.id}"]`);
+        if (elementSpan) {
+            elementSpan.classList.add('highlighted');
+            
+            let currentElement = element;
+            while (currentElement.parent) {
+                const parentElement = this.elements.find(e => e.id === currentElement.parent);
+                if (parentElement) {
+                    const parentSpan = this.container.querySelector(`[data-element-id="${parentElement.id}"]`);
+                    if (parentSpan) {
+                        parentSpan.classList.add('highlighted');
+                    }
+                    currentElement = parentElement;
+                } else {
+                    break;
+                }
+            }
+        }
+    }
+
+    setupCaretHandlers() {
+        this.container.querySelectorAll('.caret').forEach(caret => {
+            caret.addEventListener('click', function() {
+                this.classList.toggle('caret-down');
+                const nestedList = getNextSibling(this, '.nested');
+                if (nestedList) {
+                    nestedList.classList.toggle('active');
+                }
+            });
+        });
+    }
+
+    setupExpandAllHandler() {
+        const expandAllBtn = this.container.querySelector('.expand-all-btn');
+        expandAllBtn.addEventListener('click', function() {
+            const isExpanded = this.dataset.expanded === 'true';
+            const carets = document.querySelectorAll('.caret');
+            
+            carets.forEach(caret => {
+                const nestedList = getNextSibling(caret, '.nested');
+                if (isExpanded) {
+                    // Collapse all
+                    caret.classList.toggle('caret-down');
+                    if (nestedList) {
+                        nestedList.classList.toggle('active');
+                    }
+                } else {
+                    // Expand all
+                    caret.classList.toggle('caret-down');
+                    if (nestedList) {
+                        nestedList.classList.toggle('active');
+                    }
+                }
+            });
+            
+            // Toggle button state
+            this.dataset.expanded = (!isExpanded).toString();
+            this.textContent = isExpanded ? 'Expand All' : 'Collapse All';
+        });
+    }
+}


### PR DESCRIPTION
Hi team!

This pull request adds an option for a table of contents to the interactive datamap. One of my projects leveraging datamaps has received user feedback that a more structured view of the label heirarchy would be valuable alongside the datamap, to identify all of the cluster labels present and assist in a more systematic exploration of the datamap. I figured this would more easily (and more robustly) be done with contributions to the library than a massive chunk of custom js.

The table of contents is built from extra data passed to the labelData, including parent labels (clusters directly above in the heirarchy) and related points (all of the point indexes related to the label). It has a nested structure, and the table of contents labels that are on screen are highlighted as the user interacts with the map. Clicking on a label in the table of contents will also zoom the map to the cluster in question. This should aid moving back and forth between the structure of the table of contents and the fluidity of the datamap, making it easy to move from one to the other.

I've also added an optional button that is incuded in the table of contents next to each label. This button can take custom js like the `on_click` kwarg, and will be passed a list of attributes from each of the associated points. This can be used to, say, open up all points in a cluster if the destination can handle a list of elements, instead of having to interact with each point individually.

I'm more than prepared to be told my java script and css is rubbish, please let me know where it can be improved. Also unsure if the modifications to `label_text_and_polygon_dataframes` are the best way to achieve the label data structure.

I have been unable to build the doccumentation unfortunately, but am happy to work on getting that done too. I was thinking just another cell in the `interactive_customization_options.ipynb` notebook.

Let me know what you think/if there are any issues :)