### PR TITLE
Update to nightly test runs

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -17,11 +17,11 @@ pr:
     - doc/*
     - README.rst
 
-# Trigger a run on main at 00:00 (midnight) UTC on Sundays
+# Trigger a run on main at 00:00 (midnight) UTC every day
 # Run even if there are no code changes
 schedules:
-  - cron: "0 0 * * 0"
-    displayName: "Sunday Test Runs"
+  - cron: "0 0 * * *"
+    displayName: "Nightly Test Runs"
     always: true
     branches:
       include:

--- a/datamapplot/interactive_tests/tests/cord_canvas.spec.ts
+++ b/datamapplot/interactive_tests/tests/cord_canvas.spec.ts
@@ -2,8 +2,8 @@ import { test, expect } from '@playwright/test';
 
 test.describe('Cord19 Canvas Tests', () => {
   test.beforeEach(async ({ page }, testInfo) => {
-    // Extend timeout for all tests running this hook by 4 minutes.
-    testInfo.setTimeout(testInfo.timeout + 240_000);
+    // Extend timeout for all tests running this hook by 5 minutes.
+    testInfo.setTimeout(testInfo.timeout + 300_000);
     // Set consistent viewport size
     await page.setViewportSize({ width: 1280, height: 720 });
 


### PR DESCRIPTION
Change from weekly to nightly slow test runs and extend the timeout on the slow cord19 page loading.