### PR TITLE
Python 3.9 support fix

### DIFF
--- a/datamapplot/config.py
+++ b/datamapplot/config.py
@@ -3,8 +3,13 @@ import inspect as ins
 import json
 from pathlib import Path
 import platformdirs
-from typing import Any, Callable, cast, ParamSpec, TypeVar, Union
+from typing import Any, Callable, cast, TypeVar, Union
 from warnings import warn
+
+try:
+    from typing import ParamSpec
+except ImportError:
+    from typing_extensions import ParamSpec
 
 
 P = ParamSpec("P")


### PR DESCRIPTION
datamapplot gives an import error on python 3.9 due to the use of ParamSpec from typing (added in 3.10).
We can preserve backwards compatibility for now with typing-extensions.