### PR TITLE
Add offline_data_path parameter for better file organization

### DIFF
--- a/datamapplot/create_plots.py
+++ b/datamapplot/create_plots.py
@@ -359,6 +359,7 @@ def create_interactive_plot(
     cvd_safer=False,
     jupyterhub_api_token=None,
     enable_table_of_contents=False,
+    offline_data_path=None,
     **render_html_kwds,
 ):
     """
@@ -470,6 +471,13 @@ def create_interactive_plot(
 
     enable_table_of_contents: bool (optional, default=False)
         Whether to build and display a table of contents with the label heirarchy.
+
+    offline_data_path: str, pathlib.Path, or None (optional, default=None)
+        If ``inline_data=False``, this specifies the path (including directory) where data 
+        files will be saved. Can be a string path or pathlib.Path object. The directory
+        will be created if it doesn't exist. If not specified, falls back to using the
+        ``offline_data_prefix`` parameter passed through ``render_html_kwds`` for backward
+        compatibility.
 
     **render_html_kwds:
         All other keyword arguments will be passed through the `render_html` function. Please
@@ -680,6 +688,7 @@ def create_interactive_plot(
         label_layers=label_layers,
         cluster_colormap=color_map | {noise_label:noise_color},
         enable_table_of_contents=enable_table_of_contents,
+        offline_data_path=offline_data_path,
         **render_html_kwds,
     )
 

--- a/datamapplot/tests/test_offline_data_path.py
+++ b/datamapplot/tests/test_offline_data_path.py
@@ -1,0 +1,108 @@
+import unittest
+import numpy as np
+import tempfile
+from pathlib import Path
+from datamapplot import create_interactive_plot
+
+
+class TestOfflineDataPath(unittest.TestCase):
+    """Test the offline_data_path parameter functionality."""
+    
+    def setUp(self):
+        """Set up test data."""
+        np.random.seed(42)
+        self.data_coords = np.random.randn(100, 2)
+        self.labels = np.random.choice(['A', 'B', 'C'], size=100)
+    
+    def test_backward_compatibility_with_prefix(self):
+        """Test that offline_data_prefix still works for backward compatibility."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Change to temp directory to avoid polluting the project
+            import os
+            original_dir = os.getcwd()
+            os.chdir(tmpdir)
+            
+            try:
+                fig = create_interactive_plot(
+                    self.data_coords,
+                    self.labels,
+                    inline_data=False,
+                    offline_data_prefix="test_prefix"
+                )
+                
+                # Check files are created with the prefix
+                assert Path("test_prefix_point_data_0.zip").exists()
+                assert Path("test_prefix_label_data.zip").exists()
+                assert Path("test_prefix_meta_data_0.zip").exists()
+            finally:
+                os.chdir(original_dir)
+    
+    def test_offline_data_path_with_directory(self):
+        """Test offline_data_path with a directory path."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_path = Path(tmpdir) / "output" / "data" / "myplot"
+            
+            fig = create_interactive_plot(
+                self.data_coords,
+                self.labels,
+                inline_data=False,
+                offline_data_path=str(output_path)
+            )
+            
+            # Check directory was created
+            assert output_path.parent.exists()
+            
+            # Check files are created in the correct location
+            assert (output_path.parent / "myplot_point_data_0.zip").exists()
+            assert (output_path.parent / "myplot_label_data.zip").exists()
+            assert (output_path.parent / "myplot_meta_data_0.zip").exists()
+    
+    def test_offline_data_path_with_path_object(self):
+        """Test offline_data_path with a Path object."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_path = Path(tmpdir) / "plots" / "viz"
+            
+            fig = create_interactive_plot(
+                self.data_coords,
+                self.labels,
+                inline_data=False,
+                offline_data_path=output_path
+            )
+            
+            # Check files are created
+            assert (output_path.parent / "viz_point_data_0.zip").exists()
+            assert (output_path.parent / "viz_label_data.zip").exists()
+    
+    def test_offline_data_path_creates_nested_directories(self):
+        """Test that nested directories are created if they don't exist."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Use a deeply nested path that doesn't exist
+            output_path = Path(tmpdir) / "a" / "b" / "c" / "d" / "plot"
+            
+            fig = create_interactive_plot(
+                self.data_coords,
+                self.labels,
+                inline_data=False,
+                offline_data_path=output_path
+            )
+            
+            # Check all directories were created
+            assert output_path.parent.exists()
+            assert (output_path.parent / "plot_point_data_0.zip").exists()
+    
+    def test_offline_data_path_with_extension(self):
+        """Test offline_data_path when user provides a path with extension."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # User might accidentally include .html extension
+            output_path = Path(tmpdir) / "output" / "myplot.html"
+            
+            fig = create_interactive_plot(
+                self.data_coords,
+                self.labels,
+                inline_data=False,
+                offline_data_path=str(output_path)
+            )
+            
+            # Should strip the extension and use the stem
+            assert (output_path.parent / "myplot_point_data_0.zip").exists()
+            assert (output_path.parent / "myplot_label_data.zip").exists()

--- a/examples/example_offline_data_path.py
+++ b/examples/example_offline_data_path.py
@@ -1,0 +1,61 @@
+"""
+Example demonstrating the new offline_data_path parameter for better control
+over where data files are saved when inline_data=False.
+"""
+
+import numpy as np
+import datamapplot
+from pathlib import Path
+
+# Generate example data
+np.random.seed(42)
+data_coords = np.random.randn(1000, 2) * 10
+labels = np.random.choice(['Category A', 'Category B', 'Category C', 'Unlabelled'], 
+                         size=1000, p=[0.3, 0.3, 0.3, 0.1])
+
+# Example 1: Using the new offline_data_path parameter
+print("Example 1: Saving data files to a specific directory")
+output_dir = Path("output/interactive_plots")
+fig = datamapplot.create_interactive_plot(
+    data_coords,
+    labels,
+    inline_data=False,
+    offline_data_path=output_dir / "example_plot",
+    title="Example with offline_data_path"
+)
+
+# Save the HTML file in the same directory
+output_dir.mkdir(parents=True, exist_ok=True)
+fig.save(str(output_dir / "example_plot.html"))
+print(f"Files saved to: {output_dir}")
+print("- example_plot.html")
+print("- example_plot_point_data_0.zip") 
+print("- example_plot_meta_data_0.zip")
+print("- example_plot_label_data.zip")
+
+# Example 2: Backward compatibility with offline_data_prefix
+print("\nExample 2: Using offline_data_prefix (backward compatibility)")
+fig2 = datamapplot.create_interactive_plot(
+    data_coords,
+    labels,
+    inline_data=False,
+    offline_data_prefix="legacy_plot",
+    title="Example with offline_data_prefix"
+)
+fig2.save("legacy_plot.html")
+print("Files saved to current directory with prefix 'legacy_plot'")
+
+# Example 3: Using Path objects
+print("\nExample 3: Using pathlib.Path objects")
+output_path = Path("visualizations") / "datamaps" / "analysis_2025"
+fig3 = datamapplot.create_interactive_plot(
+    data_coords,
+    labels,
+    inline_data=False,
+    offline_data_path=output_path,
+    title="Example with Path object"
+)
+
+# The directory is automatically created
+fig3.save(str(output_path.parent / "analysis_2025.html"))
+print(f"Files saved to: {output_path.parent}")


### PR DESCRIPTION
Pull Request: Add offline_data_path parameter for better file organization
Summary
Fixes #77 by adding a new offline_data_path parameter to control where data files are saved
Maintains full backward compatibility with existing offline_data_prefix parameter
Supports both string paths and pathlib.Path objects
Changes
Added offline_data_path parameter to create_interactive_plot() and render_html() functions
Automatically creates directories if they don't exist
Handles edge cases like paths with file extensions
Added comprehensive unit tests in datamapplot/tests/test_offline_data_path.py
Added example script in examples/example_offline_data_path.py
Usage
# New way - specify full path with directory
```
datamapplot.create_interactive_plot(
    data_coords, labels,
    inline_data=False,
    offline_data_path="output/data/my_plot"
)
```
# Also supports Path objects
```
from pathlib import Path
datamapplot.create_interactive_plot(
    data_coords, labels,
    inline_data=False,
    offline_data_path=Path("output/data/my_plot")
)
```
# Backward compatible - old way still works
```
datamapplot.create_interactive_plot(
    data_coords, labels,
    inline_data=False,
    offline_data_prefix="my_plot"  # Files in current directory
)
```
Test Plan

- All existing tests pass
- Added new unit tests for the feature
- Tested backward compatibility
- Tested directory creation
- Tested Path object support
- Tested edge cases (paths with extensions)
- Verified HTML files correctly reference data files

Notes
The implementation carefully separates the file system path from the HTML references to ensure correct behavior when files are saved in subdirectories
The offline_data_prefix parameter is marked as deprecated in the documentation but still fully functional for backward compatibility
All tests pass and the feature has been thoroughly tested with the notebook provided
This provides much better control over file organization when working with offline data mode, addressing the issue where files could only be saved in the current directory with a prefix.



<img width="1136" alt="121941751065753_ pic" src="https://github.com/user-attachments/assets/b58ae8cc-4c79-4c19-ab20-1c06c09d4113" />
<img width="840" alt="121951751065760_ pic" src="https://github.com/user-attachments/assets/0c2b961a-fc14-415c-8463-9f35c4c50044" />
<img width="1000" alt="121961751065768_ pic" src="https://github.com/user-attachments/assets/05f6e284-54fa-446c-bfda-e5fcb67b39b9" />
<img width="818" alt="121971751065779_ pic" src="https://github.com/user-attachments/assets/fade8184-9ab6-4e08-82ad-c81b7eb894ee" />
<img width="649" alt="121981751065792_ pic" src="https://github.com/user-attachments/assets/7553c42b-3d52-4948-8dbc-58c88d0fbc56" />
<img width="631" alt="121991751065802_ pic" src="https://github.com/user-attachments/assets/4cddc919-a6c1-41c9-b014-1cc233c5ba80" />
<img width="508" alt="122001751065808_ pic" src="https://github.com/user-attachments/assets/f060fb39-9423-4416-8ffb-5d14cd784303" />


