### PR TITLE
Fix offline mode font file handling

### DIFF
--- a/datamapplot/interactive_rendering.py
+++ b/datamapplot/interactive_rendering.py
@@ -314,9 +314,9 @@ class InteractiveFigure:
                 zf.write(filename)
 
 
-def get_google_font_for_embedding(fontname, offline_mode=False):
+def get_google_font_for_embedding(fontname, offline_mode=False, offline_font_file=None):
     if offline_mode:
-        all_encoded_fonts = offline_mode_caching.load_fonts()
+        all_encoded_fonts = offline_mode_caching.load_fonts(file_path=offline_font_file)
         encoded_fonts = all_encoded_fonts.get(fontname, None)
         if encoded_fonts is not None:
             font_descriptions = [
@@ -2004,7 +2004,11 @@ def render_html(
         offline_mode_data = None
 
     api_fontname = font_family.replace(" ", "+")
-    font_data = get_google_font_for_embedding(font_family, offline_mode=offline_mode)
+    font_data = get_google_font_for_embedding(
+        font_family, 
+        offline_mode=offline_mode,
+        offline_font_file=offline_mode_font_data_file if offline_mode else None
+    )
     if font_data == "":
         api_fontname = None
     if tooltip_font_family is not None:

--- a/datamapplot/tests/test_offline_font_file_handling.py
+++ b/datamapplot/tests/test_offline_font_file_handling.py
@@ -1,0 +1,166 @@
+import unittest
+import tempfile
+import json
+import numpy as np
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+import datamapplot
+from datamapplot.interactive_rendering import get_google_font_for_embedding
+
+
+class TestOfflineFontFileHandling(unittest.TestCase):
+    """Test suite for offline mode font file handling (issue #112)."""
+    
+    def setUp(self):
+        """Set up test data."""
+        # Generate simple test data
+        np.random.seed(42)
+        self.n_samples = 100
+        self.data_coords = np.random.randn(self.n_samples, 2)
+        self.labels = np.array(["Group A"] * 50 + ["Group B"] * 50)
+        
+    def test_get_google_font_for_embedding_with_custom_file(self):
+        """Test that get_google_font_for_embedding uses custom font file path."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            # Create a custom font cache file
+            font_cache_path = Path(temp_dir) / "custom_fonts.json"
+            mock_font_data = {
+                "TestFont": [{
+                    "style": "normal",
+                    "weight": "400",
+                    "unicode_range": "",
+                    "type": "ttf",
+                    "content": "VGVzdEZvbnRDb250ZW50"
+                }]
+            }
+            
+            with open(font_cache_path, 'w') as f:
+                json.dump(mock_font_data, f)
+            
+            # Test with custom file path
+            result = get_google_font_for_embedding(
+                "TestFont", 
+                offline_mode=True,
+                offline_font_file=str(font_cache_path)
+            )
+            
+            # Verify it returns the font data
+            self.assertIn("@font-face", result)
+            self.assertIn("TestFont", result)
+            self.assertIn("VGVzdEZvbnRDb250ZW50", result)
+            
+    def test_offline_mode_with_missing_font(self):
+        """Test behavior when requested font is not in the cache file."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            # Create a font cache file without the requested font
+            font_cache_path = Path(temp_dir) / "custom_fonts.json"
+            mock_font_data = {
+                "OtherFont": [{
+                    "style": "normal",
+                    "weight": "400",
+                    "unicode_range": "",
+                    "type": "ttf",
+                    "content": "T3RoZXJGb250Q29udGVudA=="
+                }]
+            }
+            
+            with open(font_cache_path, 'w') as f:
+                json.dump(mock_font_data, f)
+            
+            # Test with font not in cache
+            result = get_google_font_for_embedding(
+                "MissingFont", 
+                offline_mode=True,
+                offline_font_file=str(font_cache_path)
+            )
+            
+            # Should return empty string when font not found
+            self.assertEqual(result, "")
+            
+    def test_create_interactive_plot_with_custom_font_file(self):
+        """Test that create_interactive_plot passes font file path correctly."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            # Create font and JS cache files
+            font_cache_path = Path(temp_dir) / "fonts.json"
+            js_cache_path = Path(temp_dir) / "js.json"
+            
+            mock_font_data = {
+                "Arial": [{
+                    "style": "normal",
+                    "weight": "400",
+                    "unicode_range": "",
+                    "type": "ttf",
+                    "content": "QXJpYWxGb250Q29udGVudA=="
+                }]
+            }
+            
+            mock_js_data = {
+                "https://unpkg.com/deck.gl@latest/dist.min.js": {
+                    "encoded_content": "ZGVja2dsX2NvbnRlbnQ=",
+                    "name": "unpkg_com_deck_gl_latest_dist_min_js"
+                }
+            }
+            
+            with open(font_cache_path, 'w') as f:
+                json.dump(mock_font_data, f)
+            with open(js_cache_path, 'w') as f:
+                json.dump(mock_js_data, f)
+            
+            # Create plot with custom font file
+            fig = datamapplot.create_interactive_plot(
+                self.data_coords,
+                self.labels,
+                inline_data=False,
+                offline_mode=True,
+                offline_mode_font_data_file=str(font_cache_path),
+                offline_mode_js_data_file=str(js_cache_path),
+                font_family="Arial"
+            )
+            
+            # Verify the plot was created successfully
+            self.assertIsNotNone(fig)
+            self.assertIsInstance(fig, datamapplot.interactive_rendering.InteractiveFigure)
+            
+    def test_offline_mode_without_custom_file_uses_default(self):
+        """Test that offline mode falls back to default cache when no file specified."""
+        with patch('datamapplot.offline_mode_caching.load_fonts') as mock_load_fonts:
+            # Set up mock to return empty dict
+            mock_load_fonts.return_value = {}
+            
+            # Call without custom file path
+            result = get_google_font_for_embedding(
+                "SomeFont", 
+                offline_mode=True,
+                offline_font_file=None
+            )
+            
+            # Verify it called load_fonts with None (default behavior)
+            mock_load_fonts.assert_called_once_with(file_path=None)
+            
+    def test_online_mode_ignores_font_file_parameter(self):
+        """Test that online mode ignores the offline font file parameter."""
+        with patch('datamapplot.fonts.can_reach_google_fonts', return_value=True), \
+             patch('datamapplot.fonts.query_google_fonts') as mock_query:
+            
+            # Set up mock
+            mock_font = MagicMock()
+            mock_font.url = "https://fonts.googleapis.com/font.ttf"
+            mock_collection = MagicMock()
+            mock_collection.__iter__ = lambda self: iter([mock_font])
+            mock_collection.content = "@font-face { font-family: 'Test'; }"
+            mock_query.return_value = mock_collection
+            
+            # Call in online mode with font file (should be ignored)
+            result = get_google_font_for_embedding(
+                "TestFont", 
+                offline_mode=False,
+                offline_font_file="/path/to/fonts.json"
+            )
+            
+            # Should query Google Fonts, not use the file
+            mock_query.assert_called_once_with("TestFont")
+            self.assertIn("@font-face", result)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/examples/example_offline_custom_font_file.py
+++ b/examples/example_offline_custom_font_file.py
@@ -1,0 +1,103 @@
+"""
+Example demonstrating offline mode with custom font file paths.
+This addresses issue #112 where offline mode would fail when specifying individual files.
+"""
+
+import numpy as np
+import datamapplot
+import tempfile
+import json
+from pathlib import Path
+
+# Generate example data
+np.random.seed(42)
+n_samples = 1000
+n_clusters = 5
+
+# Create cluster centers
+centers = np.random.randn(n_clusters, 2) * 10
+
+# Generate data points around centers
+data_coords = []
+labels = []
+
+for i, center in enumerate(centers):
+    n_points = n_samples // n_clusters
+    cluster_data = np.random.randn(n_points, 2) + center
+    data_coords.append(cluster_data)
+    labels.extend([f"Cluster {i+1}"] * n_points)
+
+# Add some noise points
+noise_points = np.random.uniform(-15, 15, (n_samples // 10, 2))
+data_coords.append(noise_points)
+labels.extend(["Unlabelled"] * len(noise_points))
+
+# Combine all data
+data_coords = np.vstack(data_coords)
+labels = np.array(labels)
+
+print("Creating example with custom font cache file...")
+
+# Create a temporary directory for demonstration
+with tempfile.TemporaryDirectory() as temp_dir:
+    # Path for our custom font cache
+    custom_font_file = Path(temp_dir) / "my_custom_fonts.json"
+    
+    # Create a minimal font cache (in practice, you'd use dmp_offline_cache to generate this)
+    font_cache = {
+        "Roboto": [{
+            "style": "normal",
+            "weight": "400", 
+            "unicode_range": "",
+            "type": "woff2",
+            "content": "d09GMgABAAAAAAIAAA4AAAAAA..."  # Truncated for example
+        }]
+    }
+    
+    with open(custom_font_file, 'w') as f:
+        json.dump(font_cache, f)
+    
+    print(f"Created custom font cache at: {custom_font_file}")
+    
+    # Also need a JS cache file for offline mode
+    js_cache_file = Path(temp_dir) / "my_js_cache.json"
+    js_cache = {
+        "https://unpkg.com/deck.gl@latest/dist.min.js": {
+            "encoded_content": "ZGVja2dsX2NvbnRlbnQ=",  # Placeholder
+            "name": "unpkg_com_deck_gl_latest_dist_min_js"
+        }
+    }
+    
+    with open(js_cache_file, 'w') as f:
+        json.dump(js_cache, f)
+    
+    try:
+        # Create interactive plot with custom font file
+        fig = datamapplot.create_interactive_plot(
+            data_coords,
+            labels,
+            title="Offline Mode with Custom Font File",
+            sub_title="Using specified font cache file instead of default location",
+            font_family="Roboto",
+            inline_data=False,
+            offline_mode=True,
+            offline_mode_font_data_file=str(custom_font_file),
+            offline_mode_js_data_file=str(js_cache_file),
+            offline_data_path=temp_dir / "plot_data"
+        )
+        
+        # Save the plot
+        output_file = Path(temp_dir) / "offline_custom_font_plot.html"
+        fig.save(str(output_file))
+        
+        print(f"\nSuccess! Plot saved to: {output_file}")
+        print("\nThis demonstrates the fix for issue #112:")
+        print("- Offline mode now correctly uses specified font file paths")
+        print("- No longer defaults to potentially non-existent cache locations")
+        
+    except Exception as e:
+        print(f"\nError: {e}")
+        print("\nNote: For a real use case, you would:")
+        print("1. Use 'dmp_offline_cache' to create proper font/JS cache files")
+        print("2. Store them in your desired location")
+        print("3. Reference them using the offline_mode_*_data_file parameters")


### PR DESCRIPTION
# Fix offline mode font file handling

## Description

This PR fixes issue #112 where offline mode fails when specifying individual font files instead of using the default cache location.

## Problem

When using `offline_mode_font_data_file` parameter, the custom font file path was not being passed to the font loading function (`get_google_font_for_embedding`). This caused the function to always default to the standard cache location, which might not exist, resulting in offline mode failures.

## Solution

- Updated `get_google_font_for_embedding()` to accept an optional `offline_font_file` parameter
- Modified the call in `render_html()` to pass the `offline_mode_font_data_file` when in offline mode
- The fix ensures that custom font cache files are properly loaded when specified

## Changes

1. **`interactive_rendering.py`**:
   - Added `offline_font_file` parameter to `get_google_font_for_embedding()`
   - Updated the function call to pass `offline_mode_font_data_file` when available

2. **Tests**:
   - Added comprehensive unit tests in `test_offline_font_file_handling.py`
   - Tests cover custom file usage, missing fonts, and fallback behavior

3. **Example**:
   - Added `example_offline_custom_font_file.py` demonstrating the fix
   - Shows how to use custom font cache files in offline mode

## Testing

```bash
# Run the unit tests
python -m unittest datamapplot.tests.test_offline_font_file_handling

# Try the example
python examples/example_offline_custom_font_file.py
```

## Notes

- This fix is backward compatible - existing code will continue to work
- When no custom font file is specified, it falls back to the default behavior
- The fix makes offline mode more flexible for users who need to manage their own cache files

Fixes #112