### PR TITLE
Close #138 by accepting local files as logo

### DIFF
--- a/datamapplot/interactive_rendering.py
+++ b/datamapplot/interactive_rendering.py
@@ -7,6 +7,9 @@ import warnings
 import zipfile
 import json
 import platformdirs
+from urllib.error import HTTPError, URLError
+from urllib.parse import urlparse
+from urllib.request import urlopen
 
 import jinja2
 import numpy as np
@@ -1077,29 +1080,28 @@ def label_text_and_polygon_dataframes(
 
 def url_to_base64_img(url):
     try:
-        # Download the image
-        response = requests.get(url, timeout=10)
-        response.raise_for_status()
-
-        # Determine the image type from the Content-Type header
-        content_type = response.headers.get("Content-Type", "")
-        if not content_type.startswith("image/"):
-            raise ValueError(
-                f"URL does not point to an image (Content-Type: {content_type})"
-            )
-
-        # Convert the image data to base64
-        image_data = base64.b64encode(response.content).decode("utf-8")
-
-        # Create the complete data URL
-        return f"data:{content_type};base64,{image_data}"
-
-    except requests.RequestException as e:
-        print(f"Error downloading image: {e}")
+        # Download the image.
+        # The requests library doesn't support the file scheme so use urllib.
+        with urlopen(url, timeout=10) as response:
+            data = response.read()
+            content_type = response.info().get_content_type()
+    except HTTPError as e:
+        print(f"Error downloading image: HTTP error {e.code} {e.reason}")
         return None
-    except Exception as e:
-        print(f"Error processing image: {e}")
+    except URLError as e:
+        print(f"Error downloading image: Network error {e.reason}")
         return None
+
+    # Determine the image type from the response content type.
+    if not content_type.startswith("image/"):
+        print(f"URL {url} has content type {content_type} not image")
+        return None
+
+    # Convert the image data to base64.
+    image_data = base64.b64encode(data).decode("utf-8")
+
+    # Create the complete data URI.
+    return f"data:{content_type};base64,{image_data}"
 
 
 @cfg.complete(unconfigurable={"point_dataframe", "label_dataframe"})
@@ -1249,7 +1251,7 @@ def render_html(
 
     logo: str or None (optional, default=None)
         A logo image to include in the bottom right corner of the map. This should be
-        a URL to the image.
+        a URL to the image with an http, https, or file scheme.
 
     logo_width: int (optional, default=256)
         The width, in pixels, of the logo to be included in the bottom right corner.
@@ -1953,7 +1955,7 @@ def render_html(
 
     if dynamic_tooltip is not None:
         enable_dynamic_tooltip = True
-        tooltip_identifier_js = dynamic_tooltip['identifier_js']
+        tooltip_identifier_js = dynamic_tooltip["identifier_js"]
         tooltip_fetch_js = dynamic_tooltip["fetch_js"]
         tooltip_format_js = dynamic_tooltip["format_js"]
         tooltip_loading_js = dynamic_tooltip["loading_js"]
@@ -1999,6 +2001,20 @@ def render_html(
 
     template = jinja2.Template(_DECKGL_TEMPLATE_STR)
 
+    if logo is not None:
+        scheme = urlparse(logo).scheme
+        if not scheme:
+            # HTML will think logo is a relative path and fail to load it.
+            raise ValueError(
+                (
+                    "No scheme supplied for logo URL. "
+                    f"Perhaps you meant https://{logo}?"
+                )
+            )
+        elif offline_mode or scheme == "file":
+            # Store the image inline as a base64 URI.
+            logo = url_to_base64_img(logo)
+
     if offline_mode:
         if offline_mode_js_data_file is None:
             data_directory = platformdirs.user_data_dir("datamapplot")
@@ -2018,10 +2034,6 @@ def render_html(
             )
             if not offline_mode_font_data_file.is_file():
                 offline_mode_caching.cache_fonts()
-
-        if logo is not None:
-            logo = url_to_base64_img(logo)
-
     else:
         offline_mode_data = None
 


### PR DESCRIPTION
Manually tested with
```python
import datamapplot
import numpy as np
from pathlib import Path
import urllib

logo = "https://raw.githubusercontent.com/TutteInstitute/.github/main/profile/images/tutte-long.png"

data_map = np.random.uniform(size=[10, 2])
label_layers = ["a"] * data_map.shape[0]

plot = datamapplot.create_interactive_plot(data_map, label_layers, logo=logo, offline_mode=True)
Path("test.html").write_text(plot._html_str)

plot = datamapplot.create_interactive_plot(data_map, label_layers, logo=logo, offline_mode=False)
Path("test.html").write_text(plot._html_str)

with urllib.request.urlopen(logo) as response:
	Path("logo.png").write_bytes(response.read())

logo = Path("logo.png").resolve().as_uri()

plot = datamapplot.create_interactive_plot(data_map, label_layers, logo=logo, offline_mode=True)
Path("test.html").write_text(plot._html_str)

plot = datamapplot.create_interactive_plot(data_map, label_layers, logo=logo, offline_mode=False)
Path("test.html").write_text(plot._html_str)
```