### PR TITLE
Make label filter more robust

### DIFF
--- a/datamapplot/deckgl_template.html
+++ b/datamapplot/deckgl_template.html
@@ -636,7 +636,7 @@
           // Only build labels where we have a position.
           datamap.addLabels(
             {%- if enable_topic_tree -%}
-            labelData.filter((d) => {return !(d.id.endsWith('-1'))})
+            labelData.filter((d) => {return !(d.id && d.id.endsWith('-1'))})
             {%- else -%}
             labelData
             {%- endif -%}, {


### PR DESCRIPTION
I have observed, when loading data from bundle files for a large map, that the argument to the label filter is sometimes undefined. As such, it has no `id` field, and the `d.id.endsWith` predicate raises an exception. This in turn blocks the label loading, and the user observes a label progress bar that stays stuck, and labels never populate across the map.