### PR TITLE
Make identifier_js part of tooltip API facultative

### DIFF
--- a/datamapplot/deckgl_template.html
+++ b/datamapplot/deckgl_template.html
@@ -906,7 +906,7 @@
     const tooltip = new DynamicTooltipManager(
       datamap,
       {
-        getIdentifier: {{tooltip_identifier_js}},
+        {%- if tooltip_identifier_js %}getIdentifier: {{tooltip_identifier_js}},{% endif -%}
         fetchData: {{tooltip_fetch_js}},
         formatContent: {{tooltip_format_js}},
         formatLoading: {{tooltip_loading_js}},

--- a/datamapplot/interactive_rendering.py
+++ b/datamapplot/interactive_rendering.py
@@ -1965,7 +1965,7 @@ def render_html(
 
     if dynamic_tooltip is not None:
         enable_dynamic_tooltip = True
-        tooltip_identifier_js = dynamic_tooltip["identifier_js"]
+        tooltip_identifier_js = dynamic_tooltip.get("identifier_js", None)
         tooltip_fetch_js = dynamic_tooltip["fetch_js"]
         tooltip_format_js = dynamic_tooltip["format_js"]
         tooltip_loading_js = dynamic_tooltip["loading_js"]


### PR DESCRIPTION
The recent changes to make the dynamic tooltip API more flexible broke outstanding usages, notably the Wikipedia data maps that @lmcinnes and I are putting together for publication. This change makes the usage of identifier extraction not mandatory to use dynamic tooltips, falling back on a sane default implementation.