### PR TITLE
Update edge bundling test to read from compressed sample data

### DIFF
--- a/examples/plot_arxiv_ml_edge_bundle.py
+++ b/examples/plot_arxiv_ml_edge_bundle.py
@@ -14,8 +14,8 @@ import colorcet
 
 plt.rcParams["savefig.bbox"] = "tight"
 
-arxivml_data_map = np.load("arxiv_ml_data_map.npy")
-arxivml_labels = np.load("arxiv_ml_cluster_labels.npy", allow_pickle=True)
+arxivml_data_map = np.load("arxiv_ml_data_map.npz")["arr_0"]
+arxivml_labels = np.load("arxiv_ml_cluster_labels.npz", allow_pickle=True)["arr_0"]
 
 arxiv_logo_response = requests.get(
     "https://upload.wikimedia.org/wikipedia/commons/thumb/b/bc/ArXiv_logo_2022.svg/320px-ArXiv_logo_2022.svg.png",


### PR DESCRIPTION
Looks like this test was missed when the sample datasets were compressed. Updated to read from the new compressed datasets.