### PR TITLE
Also treat booleans as categorical in default_colormap_options

### DIFF
--- a/datamapplot/interactive_rendering.py
+++ b/datamapplot/interactive_rendering.py
@@ -567,7 +567,7 @@ def default_colormap_options(values_dict):
         colormap_metadata["field"] = candidate_field
         colormap_metadata["description"] = name
 
-        if values.dtype.kind in ["U", "S", "O"]:
+        if values.dtype.kind in ["U", "S", "O", "b"]:
             colormap_metadata["kind"] = "categorical"
             n_categories = len(np.unique(values))
             n = 0
@@ -672,7 +672,7 @@ def array_to_colors(values, cmap_name, metadata, color_list=None):
         # String, object, or boolean type.
         valid_mask = get_valid_mask(values)
         if not np.any(valid_mask):
-            raise ValueError("No valid string values found")
+            raise ValueError("No valid string, object, or boolean values found")
 
         # Get unique valid values
         unique_values = np.unique(values[valid_mask])


### PR DESCRIPTION
The default case was missed in commit e1e259f .
Tested with
```python
import datamapplot
import numpy as np

# Numeric data, vmin and vmax outside empirical range.
data_map = np.random.uniform(size=[5, 2])
label_layers = ["Unlabelled"] * data_map.shape[0]
colormaps = {"boolean": np.asarray([True, True, False, False, False])}
plot = datamapplot.create_interactive_plot(data_map, label_layers, colormaps=colormaps)
plot.save("test.html")
```