### PR TITLE
Pin deck.gl to 9.1 to fix region labels invisible on initial interactive-plot load (#188)

### DIFF
--- a/datamapplot/interactive_helpers.py
+++ b/datamapplot/interactive_helpers.py
@@ -398,7 +398,11 @@ def get_js_dependency_urls(
         A list of URLs that point to the required JavaScript dependencies.
     """
     js_dependency_urls = [
-        f"https://{cdn_url}/deck.gl@latest/dist.min.js",
+        # deck.gl is pinned to 9.1: 9.2 regressed CollisionFilterExtension so
+        # that region labels are culled on the first render and only appear
+        # after a viewport change. Bisected 9.1 (good) -> 9.2 (bad); 9.3.x is
+        # still affected. Unpin once the upstream regression is fixed.
+        f"https://{cdn_url}/deck.gl@9.1/dist.min.js",
         f"https://{cdn_url}/apache-arrow@latest/Arrow.es2015.min.js",
     ]
 

--- a/datamapplot/offline_mode_caching.py
+++ b/datamapplot/offline_mode_caching.py
@@ -17,7 +17,9 @@ from zipfile import ZipFile, ZIP_DEFLATED
 from warnings import warn
 
 DEFAULT_URLS = [
-    "https://unpkg.com/deck.gl@latest/dist.min.js",
+    # deck.gl pinned to 9.1 (see get_js_dependency_urls in interactive_helpers
+    # for the reason); keep this version in sync with that one.
+    "https://unpkg.com/deck.gl@9.1/dist.min.js",
     "https://unpkg.com/apache-arrow@latest/Arrow.es2015.min.js",
     "https://unpkg.com/d3@latest/dist/d3.min.js",
     "https://unpkg.com/jquery@3.7.1/dist/jquery.min.js",


### PR DESCRIPTION
Pins the deck.gl CDN dependency to `9.1` (from `@latest`) in `interactive_helpers.py` and `offline_mode_caching.py`.

**Why:** interactive plots load `deck.gl@latest`, which advanced to 9.2+ and pulled in a `CollisionFilterExtension` regression — the collision FBO is sized from deck's initial 300×150 canvas and isn't recomputed after the canvas resizes, so every region label is culled on first render until any viewport change. That's the cause of #188 (the original WebFont / SDF-atlas theory turned out to be wrong; details in the thread). Bisected: 9.1.x renders correctly on first load, 9.2.x and 9.3.x don't. Root-caused upstream at visgl/deck.gl#10333.

**Scope:** deck.gl 9.2/9.3 added nothing datamapplot uses — the deck API surface here is all classic layers and extensions, none of them 9.2/9.3 additions, so the pin forfeits nothing in use.

**Validation:** regenerated a real map with the pin and confirmed region labels render on initial load (incognito) where the `@latest` build shows none; `pytest -m interactive` passes on the branch.

**Follow-up:** unpin once visgl/deck.gl#10333 is fixed upstream.

Fixes #188
