### PR TITLE
Hierarchical collision priority for multi-layer interactive labels

### DIFF
--- a/datamapplot/create_plots.py
+++ b/datamapplot/create_plots.py
@@ -375,6 +375,7 @@ def create_interactive_plot(
     enable_topic_tree=False,
     offline_data_path=None,
     histogram_enable_click_persistence=False,
+    hierarchical_collision_priority=True,
     **render_html_kwds,
 ):
     """
@@ -494,6 +495,17 @@ def create_interactive_plot(
         ``offline_data_prefix`` parameter passed through ``render_html_kwds`` for backward
         compatibility.
 
+    hierarchical_collision_priority: bool (optional, default=True)
+        When more than one ``label_layers`` array is supplied, give labels from
+        coarser layers a higher collision priority than labels from finer layers,
+        so a coarse label always wins when it overlaps a finer one (cluster size
+        breaks ties within a layer). This works around a deck.gl
+        ``CollisionFilterExtension`` precision limitation that otherwise lets
+        labels flicker or pick the wrong winner across layers as you zoom (see
+        TutteInstitute/datamapplot#192, visgl/deck.gl#10346). Set to ``False`` to
+        fall back to the previous size-only collision behaviour. Has no effect on
+        single-layer maps.
+
     **render_html_kwds:
         All other keyword arguments will be passed through the `render_html` function. Please
         see the docstring of that function for further options that can control the
@@ -578,21 +590,28 @@ def create_interactive_plot(
         #
         label_lists[-1]["lowest_layer"] = True
 
+        # Tag each layer's labels with its original (non-reversed) position so
+        # collision priority can be spread across the hierarchy (#192).
+        for reverse_index, layer_frame in enumerate(label_lists):
+            layer_frame["layerIdx"] = len(label_layers) - 1 - reverse_index
         label_dataframe = pd.concat(label_lists)
     else:
-        label_dataframe = pd.concat(
-            [
-                label_text_and_polygon_dataframes(
-                    labels,
-                    data_map_coords,
-                    noise_label=noise_label,
-                    use_medoids=use_medoids,
-                    cluster_polygons=cluster_boundary_polygons,
-                    alpha=polygon_alpha,
-                )
-                for labels in label_layers
-            ]
-        )
+        label_lists = [
+            label_text_and_polygon_dataframes(
+                labels,
+                data_map_coords,
+                noise_label=noise_label,
+                use_medoids=use_medoids,
+                cluster_polygons=cluster_boundary_polygons,
+                alpha=polygon_alpha,
+            )
+            for labels in label_layers
+        ]
+        # Tag each layer's labels with its position so collision priority can be
+        # spread across the hierarchy (#192).
+        for layer_index, layer_frame in enumerate(label_lists):
+            layer_frame["layerIdx"] = layer_index
+        label_dataframe = pd.concat(label_lists)
 
     # remove_duplicate_chains(label_dataframe)
 
@@ -736,6 +755,7 @@ def create_interactive_plot(
         darkmode=darkmode,
         noise_color=noise_color,
         label_layers=label_layers,
+        hierarchical_collision_priority=hierarchical_collision_priority,
         cluster_colormap=color_map | {noise_label: noise_color},
         enable_topic_tree=enable_topic_tree,
         offline_data_path=offline_data_path,

--- a/datamapplot/interactive_helpers.py
+++ b/datamapplot/interactive_helpers.py
@@ -1997,6 +1997,77 @@ def compute_point_scaling(point_dataframe, bounds, point_size_scale=None):
     return magic_number, point_size, point_dataframe
 
 
+def compute_collision_priority(label_dataframe, priority_range=900.0):
+    """Spread label collision priorities across hierarchy layers.
+
+    deck.gl's ``CollisionFilterExtension`` uses a 16-bit depth FBO, which gives
+    only ~32 buckets per unit of collision-priority gap; gaps below ~3 produce
+    noisy, non-monotonic label visibility (TutteInstitute/datamapplot#192,
+    visgl/deck.gl#10346). When labels come from multiple hierarchy layers we
+    spread the priorities so the layer index dominates and ``size`` is only a
+    within-layer tiebreaker, keeping adjacent-layer gaps well above the
+    precision threshold.
+
+    By DataMapPlot's label-layer convention the first layer passed
+    (``layerIdx`` 0) is the finest and the last is the coarsest, matching how
+    point colours and the topic tree are already derived. The coarsest layer is
+    given the highest priority so it wins collisions against finer overlapping
+    layers (the same coarse-beats-fine behaviour you get when zoomed out). All
+    values stay within ``[-priority_range, priority_range]`` to remain inside
+    deck.gl's clip-space-safe range.
+
+    This is a no-op (the frame is returned unchanged) when there is no
+    ``layerIdx`` column or only a single layer is present, so single-layer maps
+    and direct ``render_html`` callers are unaffected.
+
+    Parameters
+    ----------
+    label_dataframe : pandas.DataFrame
+        Label data with a ``size`` column (assumed already scaled by
+        ``compute_label_scaling``) and, for multi-layer maps, a ``layerIdx``
+        column tagging each label with its source layer.
+
+    priority_range : float (optional, default=900.0)
+        Half-width of the clip-safe priority band. Values are placed within
+        ``[-priority_range, priority_range]``.
+
+    Returns
+    -------
+    label_dataframe : pandas.DataFrame
+        The input frame, with an added ``collision_priority`` column when the
+        spread was applied.
+    """
+    if "layerIdx" not in label_dataframe.columns:
+        return label_dataframe
+
+    present_layers = sorted(label_dataframe["layerIdx"].dropna().unique())
+    n_layers = len(present_layers)
+    if n_layers <= 1:
+        return label_dataframe
+
+    label_dataframe = label_dataframe.copy()
+    step = (2.0 * priority_range) / n_layers
+    dense_rank = {layer: rank for rank, layer in enumerate(present_layers)}
+    layer_rank = label_dataframe["layerIdx"].map(dense_rank)
+
+    # Center each layer's band. layerIdx 0 is the finest layer, so invert the
+    # rank to give the coarsest layer (highest layerIdx) the highest priority.
+    inverted_rank = (n_layers - 1) - layer_rank
+    base = priority_range - (inverted_rank + 0.5) * step
+
+    # Keep the size tiebreaker within (-step/4, step/4) so layers never overlap.
+    size = label_dataframe["size"]
+    size_min = size.min()
+    size_max = size.max()
+    if size_max > size_min:
+        tiebreaker = ((size - size_min) / (size_max - size_min) - 0.5) * (step / 2.0)
+    else:
+        tiebreaker = 0.0
+
+    label_dataframe["collision_priority"] = base + tiebreaker
+    return label_dataframe
+
+
 def compute_label_scaling(label_dataframe, min_fontsize, max_fontsize):
     """
     Compute label text size scaling.

--- a/datamapplot/interactive_rendering.py
+++ b/datamapplot/interactive_rendering.py
@@ -52,6 +52,7 @@ from datamapplot.interactive_helpers import (
     default_colormap_options,
     per_layer_cluster_colormaps,
     compute_point_scaling,
+    compute_collision_priority,
     compute_label_scaling,
     get_style_config,
     get_label_text_color,
@@ -507,6 +508,7 @@ def render_html(
     colormap_metadata=None,
     cluster_layer_colormaps=False,
     label_layers=None,
+    hierarchical_collision_priority=True,
     cluster_colormap=None,
     enable_topic_tree=False,
     topic_tree_kwds={},
@@ -834,6 +836,16 @@ def render_html(
         data is split into multiple layers, and you would like users to be able to select
         individual clustering resolutions to colour by.
 
+    hierarchical_collision_priority: bool (optional, default=True)
+        When the label data spans multiple hierarchy layers (carrying a ``layerIdx``
+        column), spread label collision priorities so coarser layers win over finer
+        layers on overlap, with cluster size breaking ties within a layer. This works
+        around a deck.gl ``CollisionFilterExtension`` precision limitation that
+        otherwise lets labels flicker or pick the wrong winner across layers as you
+        zoom (see TutteInstitute/datamapplot#192, visgl/deck.gl#10346). Set to
+        ``False`` for the previous size-only collision behaviour. Has no effect when
+        there is a single layer or no ``layerIdx`` column.
+
     enable_topic_tree: bool (optional, default=False)
         Whether to enable a topic tree that highlights label heirarchy and aids navigation in
         the datamap.
@@ -1024,6 +1036,8 @@ def render_html(
 
     # Compute label text scaling
     label_dataframe = compute_label_scaling(label_dataframe, min_fontsize, max_fontsize)
+    if hierarchical_collision_priority:
+        label_dataframe = compute_collision_priority(label_dataframe)
 
     # Prep data for inlining or storage
     enable_histogram = histogram_data is not None

--- a/datamapplot/static/js/datamap.js
+++ b/datamapplot/static/js/datamap.js
@@ -654,7 +654,7 @@ class DataMap {
       elevation: 100,
       // CollideExtension options
       collisionEnabled: true,
-      getCollisionPriority: d => d.size,
+      getCollisionPriority: d => d.collision_priority ?? d.size,
       collisionTestProps: {
         sizeScale: this.textCollisionSizeScale,
         sizeMaxPixels: this.textMaxPixelSize * 2,

--- a/datamapplot/tests/test_interactive_plotting.py
+++ b/datamapplot/tests/test_interactive_plotting.py
@@ -1,11 +1,14 @@
 from datamapplot.interactive_rendering import InteractiveFigure, render_html
+from datamapplot.interactive_helpers import compute_collision_priority
 import datamapplot
 import sys
 import importlib.util
 from pathlib import Path
 import pytest
+import base64
 import bz2
 import gzip
+import json
 import re
 import numpy as np
 import pandas as pd
@@ -48,6 +51,19 @@ def validate_inline_data(html_content: str) -> dict:
     }
     results["is_valid"] = all(results.values())
     return results
+
+
+def decode_inline_label_data(html_content: str) -> list:
+    """Decode the inline (base64 + gzip + JSON) label records embedded in HTML.
+
+    Mirrors the encode path in ``encode_inline_data`` so tests can inspect the
+    per-label fields (e.g. ``layerIdx``, ``collision_priority``) that actually
+    reach the browser.
+    """
+    match = re.search(r'const labelDataEncoded = "([A-Za-z0-9+/=]+)"', html_content)
+    assert match, "inline labelDataEncoded payload not found in HTML"
+    raw = gzip.decompress(base64.b64decode(match.group(1)))
+    return json.loads(raw)
 
 
 def validate_offline_data_references(html_content: str, prefix: str) -> dict:
@@ -510,6 +526,167 @@ class TestCreateInteractivePlot:
         html_content = str(result)
         validation = validate_html_structure(html_content)
         assert validation["is_valid"], f"HTML validation failed: {validation}"
+
+    @staticmethod
+    def _three_layer_inputs():
+        """A small finest-first hierarchy (3 fine, 2 mid, 1 coarse cluster)."""
+        np.random.seed(0)
+        centers = [(5, 0), (5, 1), (-3, 3), (-3, -3), (4, -4), (-5, -1)]
+        fine_names = [f"fine-{i}" for i in range(6)]
+        mid_names = ["mid-A", "mid-A", "mid-B", "mid-B", "mid-C", "mid-C"]
+        coords, fine, mid, coarse = [], [], [], []
+        for center, fname, mname in zip(centers, fine_names, mid_names):
+            pts = np.array(center) + 0.4 * np.random.randn(40, 2)
+            coords.append(pts)
+            fine.extend([fname] * 40)
+            mid.extend([mname] * 40)
+            coarse.extend(["root"] * 40)
+        return (
+            np.vstack(coords),
+            np.array(fine),
+            np.array(mid),
+            np.array(coarse),
+        )
+
+    def test_hierarchical_priority_default_round_trip(self):
+        """layerIdx + collision_priority reach the inline HTML, coarse winning."""
+        coords, fine, mid, coarse = self._three_layer_inputs()
+        result = datamapplot.create_interactive_plot(
+            coords, fine, mid, coarse, inline_data=True
+        )
+        records = decode_inline_label_data(str(result))
+        labeled = [r for r in records if r.get("label") and r["label"] != "Unlabelled"]
+        assert labeled, "no labels survived to the inline payload"
+        assert all("layerIdx" in r for r in labeled)
+        assert all("collision_priority" in r for r in labeled)
+
+        priorities = {}
+        for r in labeled:
+            priorities.setdefault(r["layerIdx"], []).append(r["collision_priority"])
+        # layerIdx 0 = finest, 2 = coarsest; coarsest must rank highest.
+        assert min(priorities[2]) > max(priorities[1]) > max(priorities[0])
+
+    def test_hierarchical_priority_can_be_disabled(self):
+        """The escape hatch reproduces the legacy size-only behavior (no column)."""
+        coords, fine, mid, coarse = self._three_layer_inputs()
+        result = datamapplot.create_interactive_plot(
+            coords,
+            fine,
+            mid,
+            coarse,
+            inline_data=True,
+            hierarchical_collision_priority=False,
+        )
+        records = decode_inline_label_data(str(result))
+        labeled = [r for r in records if r.get("label") and r["label"] != "Unlabelled"]
+        assert labeled
+        assert all("collision_priority" not in r for r in labeled)
+
+    def test_single_layer_has_no_collision_priority(self):
+        """Single-layer maps never gain a collision_priority column."""
+        coords, fine, _, _ = self._three_layer_inputs()
+        result = datamapplot.create_interactive_plot(coords, fine, inline_data=True)
+        records = decode_inline_label_data(str(result))
+        labeled = [r for r in records if r.get("label") and r["label"] != "Unlabelled"]
+        assert labeled
+        assert all("collision_priority" not in r for r in labeled)
+
+
+class TestComputeCollisionPriority:
+    """Unit tests for the hierarchical collision-priority spread (#192).
+
+    These are pure-pandas and need no network or rendering, so they are not
+    marked ``interactive``.
+    """
+
+    @staticmethod
+    def _layer_frame(layer_sizes):
+        """Build a label frame from {layerIdx: [sizes]}."""
+        rows = []
+        for layer_idx, sizes in layer_sizes.items():
+            for i, size in enumerate(sizes):
+                rows.append(
+                    {
+                        "label": f"L{layer_idx}_{i}",
+                        "size": float(size),
+                        "layerIdx": layer_idx,
+                    }
+                )
+        return pd.DataFrame(rows)
+
+    def test_no_layeridx_column_is_noop(self):
+        """Without a layerIdx column the frame passes through untouched."""
+        df = pd.DataFrame({"label": ["a", "b"], "size": [18.0, 28.0]})
+        out = compute_collision_priority(df)
+        assert "collision_priority" not in out.columns
+        pd.testing.assert_frame_equal(out, df)
+
+    def test_single_layer_is_noop(self):
+        """A single hierarchy layer needs no spread (matches legacy behavior)."""
+        df = self._layer_frame({0: [18.0, 22.0, 28.0]})
+        out = compute_collision_priority(df)
+        assert "collision_priority" not in out.columns
+
+    def test_coarsest_layer_wins(self):
+        """layerIdx 0 is finest; the coarsest layer must get the top priority band."""
+        # 3 layers: 0 = finest, 2 = coarsest (DataMapPlot finest-first convention).
+        df = self._layer_frame(
+            {0: [18.0, 20.0, 22.0], 1: [22.0, 24.0], 2: [26.0, 28.0]}
+        )
+        out = compute_collision_priority(df)
+        gmin = out.groupby("layerIdx")["collision_priority"].min()
+        gmax = out.groupby("layerIdx")["collision_priority"].max()
+        # Coarsest (2) entirely above mid (1) entirely above finest (0).
+        assert gmin[2] > gmax[1] > gmin[1] > gmax[0]
+
+    def test_interlayer_gaps_clear_precision_threshold(self):
+        """Adjacent-layer gaps must clear deck.gl's ~3-unit precision band by a lot."""
+        df = self._layer_frame({0: [18.0, 28.0], 1: [18.0, 28.0], 2: [18.0, 28.0]})
+        out = compute_collision_priority(df)
+        gmin = out.groupby("layerIdx")["collision_priority"].min()
+        gmax = out.groupby("layerIdx")["collision_priority"].max()
+        assert gmin[2] - gmax[1] > 50
+        assert gmin[1] - gmax[0] > 50
+
+    def test_within_layer_size_breaks_ties(self):
+        """Inside one layer, a larger cluster size yields higher priority."""
+        df = self._layer_frame({0: [18.0, 28.0], 1: [18.0, 28.0]})
+        out = compute_collision_priority(df).set_index("label")["collision_priority"]
+        assert out["L0_1"] > out["L0_0"]  # size 28 beats size 18 within layer 0
+        assert out["L1_1"] > out["L1_0"]
+
+    def test_values_stay_in_clip_range(self):
+        """All priorities stay within deck.gl's clip-safe [-900, 900] band."""
+        # Many layers with extreme sizes is the stress case for clip overflow.
+        df = self._layer_frame({i: [10.0, 90.0] for i in range(8)})
+        out = compute_collision_priority(df)
+        assert out["collision_priority"].min() >= -900.0
+        assert out["collision_priority"].max() <= 900.0
+
+    def test_noncontiguous_layer_indices(self):
+        """Sparse/non-contiguous layerIdx values are dense-ranked and clip-safe."""
+        df = self._layer_frame({0: [18.0, 28.0], 5: [18.0, 28.0]})
+        out = compute_collision_priority(df)
+        gmin = out.groupby("layerIdx")["collision_priority"].min()
+        gmax = out.groupby("layerIdx")["collision_priority"].max()
+        # Higher index is coarser, so layer 5 outranks layer 0.
+        assert gmin[5] > gmax[0]
+        assert out["collision_priority"].abs().max() <= 900.0
+
+    def test_equal_sizes_do_not_crash(self):
+        """A layer whose labels all share one size has a zero tiebreaker, no error."""
+        df = self._layer_frame({0: [20.0, 20.0], 1: [20.0, 20.0]})
+        out = compute_collision_priority(df)
+        gmin = out.groupby("layerIdx")["collision_priority"].min()
+        gmax = out.groupby("layerIdx")["collision_priority"].max()
+        assert gmin[1] > gmax[0]
+
+    def test_does_not_mutate_input(self):
+        """The input frame is not modified in place when a spread is applied."""
+        df = self._layer_frame({0: [18.0, 28.0], 1: [18.0, 28.0]})
+        before = df.copy()
+        compute_collision_priority(df)
+        pd.testing.assert_frame_equal(df, before)
 
 
 ### Fixtures


### PR DESCRIPTION
## Summary

`create_interactive_plot` with multiple label layers (a Toponymy-style hierarchy) could show **non-monotonic label visibility** and **inverted-priority winners** while zooming: a finer-layer label would suppress the coarser label overlapping it, or labels would disappear and reappear without following any consistent order.

This is the multi-layer manifestation of [visgl/deck.gl#10346](https://github.com/visgl/deck.gl/issues/10346): `CollisionFilterExtension`'s collision FBO uses 16-bit depth, giving only ~32 buckets per unit of `getCollisionPriority` gap. The old default `getCollisionPriority: d => d.size` routinely put adjacent-layer labels within the noisy sub-~3-unit band, so the depth test picked winners unreliably.

**Version scope (corrects the issue):** bisecting in-browser, the artifact reproduces on **deck.gl 9.3 only** — not 9.2, not 9.1. (The issue speculated the precision problem was "present in 9.1 as well"; that was a source-reading inference and does not hold up empirically.) Because datamapplot is currently **pinned to deck.gl 9.1 via #193**, this is **not a live user-facing bug today** — it's a regression that returns whenever the pin is lifted (e.g. once the upstream FBO bugs are fixed and someone bumps the version). This PR is therefore defensive hardening plus an independently-desirable hierarchy-semantics change, not an urgent live fix.

Fixes #192. (Approach confirmed by @lmcinnes — ship the workaround now: https://github.com/TutteInstitute/datamapplot/issues/192#issuecomment-4587040895)

## What changed

Spread collision priorities so **layer index dominates and cluster size is only a within-layer tiebreaker**, keeping adjacent-layer gaps far above the precision threshold.

- **`create_plots.py`** — tag each label record with a `layerIdx` column (both the plain and topic-tree multi-layer branches).
- **`interactive_helpers.py`** — new `compute_collision_priority()`: adds a `collision_priority` column spreading layers across deck.gl's clip-safe `[-900, 900]` range, coarsest layer highest, size breaking ties within a layer. Returns the frame unchanged when there is no `layerIdx` column or only one layer.
- **`interactive_rendering.py`** — `render_html` calls it right after `compute_label_scaling`, gated by a new `hierarchical_collision_priority=True` kwarg.
- **`datamap.js`** — one line: `getCollisionPriority: d => d.collision_priority ?? d.size`.

Because label data is serialized with `to_json(orient="records")`, the new columns reach the browser with no template changes, and — unlike the console patch in the issue — they're baked into the source data, so they **survive `labelLayer` rebuilds** (no self-healing interval needed).

## Layer ordering — please confirm this is the intended semantic

The fix keys priority on DataMapPlot's existing **finest-first** convention: the first positional label layer is the finest, the last is the coarsest (per the `create_interactive_plot` docstring, and how the shipped `arxiv_ml`/`cord19` examples and Toponymy's `topic_names_` are ordered). The **coarsest** layer gets the **highest** priority, so coarse labels win on overlap and finer labels emerge as you zoom in. This matches the existing point-coloring loop (`for labels in reversed(label_layers)`) and the topic tree's `lowest_layer` marker.

⚠️ The synthetic repro in #192 passes its layers **coarse-first** (the opposite order). To reproduce the intended before/after with this PR, the repro call should pass layers finest-first: `create_interactive_plot(coords, fine, mid, coarse)`. With layers in coarse-first order, `main` already colors every point by the coarsest cluster (one color, in this repro) independent of this change, so coarse-first isn't a working arrangement the fix needs to preserve — hence the fix follows the documented finest-first order. Happy to adjust if you'd rather the priority be derived from per-layer cluster size so it's order-independent — I went with the documented convention to keep it simple and consistent with the rest of the pipeline.

## API / backward compatibility

- **Single-layer maps**: no `layerIdx` → formula is a no-op → `?? d.size` fallback → byte-for-byte identical output.
- **`hierarchical_collision_priority=False`**: no `collision_priority` column emitted → legacy size-only behavior.
- Direct `render_html` callers without a `layerIdx` column are unaffected.
- Kwarg name: went with the boolean `hierarchical_collision_priority` over a numeric `collision_priority_layer_weight` — the spread magnitude is a clip-overflow footgun better kept internal; the semantics are binary anyway, and a numeric blend can be added later without breaking the bool. Exposed on both `create_interactive_plot` and `render_html`, and config-file-settable via `ConfigManager` like other styling kwargs.

## Testing

- **12 new tests** in `test_interactive_plotting.py`:
  - 9 pure-function unit tests for `compute_collision_priority` — direction (coarsest wins), inter-layer gaps clear the precision threshold, within-layer size tiebreak, clip-range bounds, non-contiguous layer indices, equal sizes, no input mutation, and the two no-op cases.
  - 3 integration tests that decode the inline base64+gzip+JSON label payload from rendered HTML to confirm `layerIdx`/`collision_priority` actually reach the browser, that the escape hatch suppresses the column, and that single-layer maps stay clean.
- Existing interactive + config test suites still pass.
- **Before/after confirmed in-browser on deck.gl 9.3** (the version that exhibits the bug): with `hierarchical_collision_priority=False` the Functional Programming cluster shows the non-monotonic/stacking artifact while scroll-zooming; with it `True` the same map on the same version is clean and monotonic. On deck.gl 9.1, the live `getCollisionPriority` accessor returns the spread `collision_priority` (coarse band 750 > mid `[-49, 22]` > fine band `[-750, -618]`) rather than the `d.size` fallback, and rendering is unaffected.

## Out of scope

- This is a workaround for the upstream deck.gl precision bug ([#10346](https://github.com/visgl/deck.gl/issues/10346)); it can be revisited if/when that's fixed, though hierarchy-as-primary-axis is arguably the better default regardless.
- Per-layer `TextLayer`s with zoom-gated visibility (the structural alternative discussed in the issue) are not pursued here.
