### PR TITLE
Add configurable scroll_zoom_speed for interactive plots

### DIFF
--- a/datamapplot/interactive_rendering.py
+++ b/datamapplot/interactive_rendering.py
@@ -474,6 +474,7 @@ def render_html(
     point_line_width=0.001,
     cluster_boundary_line_width=1,
     initial_zoom_fraction=0.999,
+    scroll_zoom_speed=0.01,
     background_color=None,
     background_image=None,
     background_image_bounds=None,
@@ -682,6 +683,11 @@ def render_html(
         The fraction of of data that should be visible in the initial zoom lavel state. Sometimes
         data maps can have extreme outliers, and lowering this value to prune those out can result
         in a more useful initial view.
+
+    scroll_zoom_speed: float (optional, default=0.01)
+        The speed factor applied to scroll/wheel zooming in the interactive plot. Larger
+        values zoom faster per scroll step; smaller values zoom more gradually. The default
+        matches the previous hard-coded behaviour.
 
     background_color: str or None (optional, default=None)
         A background colour (as a hex-string) for the data map. If ``None`` a background
@@ -1538,6 +1544,7 @@ def render_html(
         cluster_boundary_polygons="polygon" in label_dataframe.columns,
         cluster_boundary_line_width=cluster_boundary_line_width,
         data_bounds=bounds,
+        scroll_zoom_speed=scroll_zoom_speed,
         n_data_chunks=n_chunks,
         on_click=on_click,
         enable_lasso_selection=enable_lasso_selection,

--- a/datamapplot/static/js/annotation.js
+++ b/datamapplot/static/js/annotation.js
@@ -332,7 +332,7 @@ class AnnotationWidget {
         // Deck.gl controller
         this.datamap.deckgl.setProps({
             controller: {
-                scrollZoom: { speed: 0.01, smooth: true },
+                scrollZoom: { speed: this.datamap.scrollZoomSpeed ?? 0.01, smooth: true },
                 dragPan: !active,
                 dragRotate: !active,
             },
@@ -873,7 +873,7 @@ class AnnotationWidget {
 
         // Restore deck.gl controller
         this.datamap.deckgl.setProps({
-            controller: { scrollZoom: { speed: 0.01, smooth: true }, dragPan: true, dragRotate: true },
+            controller: { scrollZoom: { speed: this.datamap.scrollZoomSpeed ?? 0.01, smooth: true }, dragPan: true, dragRotate: true },
             getCursor: ({ isDragging }) => isDragging ? 'grabbing' : 'grab',
         });
 

--- a/datamapplot/static/js/datamap.js
+++ b/datamapplot/static/js/datamap.js
@@ -211,10 +211,12 @@ class DataMap {
     bounds,
     searchItemId = "text-search",
     lassoSelectionItemId = "lasso-selection",
+    scrollZoomSpeed = 0.01,
   }) {
     this.container = container;
     this.searchItemId = searchItemId;
     this.lassoSelectionItemId = lassoSelectionItemId;
+    this.scrollZoomSpeed = scrollZoomSpeed;
     this.pointData = null;
     this.labelData = null;
     this.metaData = null;
@@ -228,7 +230,7 @@ class DataMap {
         longitude: dataCenter[0],
         zoom: zoomLevel
       },
-      controller: { scrollZoom: { speed: 0.01, smooth: true } },
+      controller: { scrollZoom: { speed: this.scrollZoomSpeed, smooth: true } },
     });
     this.updateTriggerCounter = 0;
     this.dataSelectionManager = new DataSelectionManager(lassoSelectionItemId);

--- a/datamapplot/templates/datamap_init.js.jinja2
+++ b/datamapplot/templates/datamap_init.js.jinja2
@@ -10,6 +10,7 @@ const datamap = new DataMap({
   container: container,
   bounds: {{ data_bounds }},
   searchItemId: searchItemId,
+  scrollZoomSpeed: {{ scroll_zoom_speed }},
   lassoSelectionItemId: selectionItemId,      
 });
 

--- a/datamapplot/tests/test_interactive_plotting.py
+++ b/datamapplot/tests/test_interactive_plotting.py
@@ -324,6 +324,27 @@ class TestRenderHtmlBasic:
         validation = validate_html_structure(html_content)
         assert validation["is_valid"], f"HTML validation failed: {validation}"
 
+    def test_render_html_scroll_zoom_speed(self, simple_point_data, simple_label_data):
+        """scroll_zoom_speed threads into the DataMap controller config."""
+        # Default preserves the previous hard-coded behaviour.
+        default_html = render_html(
+            simple_point_data, simple_label_data, inline_data=True
+        )
+        assert re.search(
+            r"scrollZoomSpeed:\s*0\.01", default_html
+        ), "default scroll_zoom_speed (0.01) not threaded into DataMap init"
+
+        # A custom value flows through to the init JS.
+        custom_html = render_html(
+            simple_point_data,
+            simple_label_data,
+            inline_data=True,
+            scroll_zoom_speed=0.05,
+        )
+        assert re.search(
+            r"scrollZoomSpeed:\s*0\.05", custom_html
+        ), "custom scroll_zoom_speed (0.05) not threaded into DataMap init"
+
 
 @pytest.mark.interactive
 class TestRenderHtmlAdvanced:
@@ -526,6 +547,21 @@ class TestCreateInteractivePlot:
         html_content = str(result)
         validation = validate_html_structure(html_content)
         assert validation["is_valid"], f"HTML validation failed: {validation}"
+
+    def test_create_interactive_plot_scroll_zoom_speed(self):
+        """scroll_zoom_speed is forwarded through create_interactive_plot (**render_html_kwds)."""
+        n_points = 100
+        np.random.seed(42)
+        data_map = np.random.randn(n_points, 2)
+        labels = np.array(["A"] * 50 + ["B"] * 50)
+
+        result = datamapplot.create_interactive_plot(
+            data_map, labels, inline_data=True, scroll_zoom_speed=0.05
+        )
+        html_content = str(result)
+        assert re.search(
+            r"scrollZoomSpeed:\s*0\.05", html_content
+        ), "scroll_zoom_speed not forwarded to the rendered HTML"
 
     @staticmethod
     def _three_layer_inputs():


### PR DESCRIPTION
Adds a `scroll_zoom_speed` parameter so the interactive plot's deck.gl scroll/wheel zoom speed can be set from Python, instead of the hard-coded `0.01`.

### What changed
- `scroll_zoom_speed` (default `0.01`) added to `render_html`; it reaches `create_interactive_plot` for free via the existing `**render_html_kwds`.
- Threaded: `render_html` context → `datamap_init.js.jinja2` (`scrollZoomSpeed`) → `DataMap` constructor → deck.gl controller.
- `annotation.js`'s drawing-mode and restore paths now read the configured value off the datamap instance (`this.datamap.scrollZoomSpeed ?? 0.01`) instead of their own hard-coded `0.01`.

### Behaviour / compatibility
- Default `0.01` preserves current behaviour exactly. Scroll speed only affects interaction, not the initial render, so there are no snapshot changes.

### Tests
- `test_render_html_scroll_zoom_speed` (param at its definition site) and `test_create_interactive_plot_scroll_zoom_speed` (forwarding via `**render_html_kwds`) assert the value threads into the init JS for both the default and a custom value.

Closes #196.

🤖 Generated with [Claude Code](https://claude.com/claude-code)