### PR TITLE
Handle empty string labels as unlabelled

### DIFF
--- a/datamapplot/create_plots.py
+++ b/datamapplot/create_plots.py
@@ -203,12 +203,14 @@ def create_plot(
         )
         unique_non_noise_labels = []
     else:
-        cluster_label_vector = np.asarray(labels, dtype=object).copy()
+        cluster_label_vector = np.asarray(labels)
         empty_label_mask = np.asarray(
             [isinstance(label, str) and label == "" for label in cluster_label_vector],
             dtype=bool,
         )
-        cluster_label_vector[empty_label_mask] = noise_label
+        if empty_label_mask.any():
+            cluster_label_vector = cluster_label_vector.astype(object, copy=True)
+            cluster_label_vector[empty_label_mask] = noise_label
         unique_non_noise_labels = [
             label for label in np.unique(cluster_label_vector) if label != noise_label
         ]

--- a/datamapplot/create_plots.py
+++ b/datamapplot/create_plots.py
@@ -203,11 +203,18 @@ def create_plot(
         )
         unique_non_noise_labels = []
     else:
-        cluster_label_vector = np.asarray(labels)
+        cluster_label_vector = np.asarray(labels, dtype=object).copy()
+        empty_label_mask = np.asarray(
+            [isinstance(label, str) and label == "" for label in cluster_label_vector],
+            dtype=bool,
+        )
+        cluster_label_vector[empty_label_mask] = noise_label
         unique_non_noise_labels = [
             label for label in np.unique(cluster_label_vector) if label != noise_label
         ]
-        if use_medoids:
+        if len(unique_non_noise_labels) == 0:
+            label_locations = np.zeros((0, 2), dtype=np.float32)
+        elif use_medoids:
             label_locations = np.asarray(
                 [
                     medoid(data_map_coords[cluster_label_vector == i])

--- a/datamapplot/tests/test_create_plot.py
+++ b/datamapplot/tests/test_create_plot.py
@@ -1,0 +1,23 @@
+from unittest.mock import patch
+
+import numpy as np
+import pytest
+
+import datamapplot as dmp
+
+
+@pytest.mark.parametrize("n_points", [2, 3])
+def test_create_plot_treats_empty_string_labels_as_unlabelled(n_points):
+    data_map = np.arange(n_points * 2, dtype=np.float32).reshape(n_points, 2)
+
+    with patch("datamapplot.create_plots.render_plot") as mock_render:
+        mock_render.return_value = (None, None)
+        dmp.create_plot(data_map, [""] * n_points, use_system_fonts=True)
+
+    _, color_list, label_text, label_locations, label_cluster_sizes = (
+        mock_render.call_args.args[:5]
+    )
+    assert color_list == ["#999999"] * n_points
+    assert label_text == []
+    np.testing.assert_array_equal(label_locations, np.zeros((0, 2), dtype=np.float32))
+    assert label_cluster_sizes.size == 0


### PR DESCRIPTION
Summary:
- Treat empty string labels as unlabelled points in create_plot.
- Preserve the no-label rendering path when all labels are empty strings.
- Add regression coverage for the 2-point and 3-point cases from the issue.

Tests:
- MPLBACKEND=Agg uv run python -m pytest datamapplot/tests/test_create_plot.py datamapplot/tests/test_no_google.py -q
- MPLBACKEND=Agg uv run python - <<'PY'
import datamapplot
import numpy as np
import pandas as pd
from matplotlib import pyplot as plt

for labels in (["", "", ""], pd.Series(["", "", ""], dtype="string")):
    data_map = np.random.default_rng(0).uniform(size=(3, 2))
    fig, ax = datamapplot.create_plot(data_map, labels, use_system_fonts=True)
    print(f"{type(labels).__name__}: {type(fig).__name__}, {type(ax).__name__}")
    plt.close(fig)
PY
- uv run python -m compileall -q datamapplot/create_plots.py datamapplot/tests/test_create_plot.py
- git diff --check

Fixes #130
