### PR TITLE
Added label filtering checkbox in search

### DIFF
--- a/datamapplot/create_plots.py
+++ b/datamapplot/create_plots.py
@@ -560,12 +560,7 @@ def create_interactive_plot(
             }
         )
     elif enable_topic_tree:
-        include_related_points = (
-            True
-            if render_html_kwds.get("topic_tree_kwds", {}).get("button_on_click")
-            is not None
-            else False
-        )
+        include_related_points = True
         # This method of allowing label_text_and_polygon_dataframes to edit parents is unsavory,
         # but means that the function has the same return statement each time and we can still use
         # list comprehension.
@@ -604,6 +599,7 @@ def create_interactive_plot(
                 use_medoids=use_medoids,
                 cluster_polygons=cluster_boundary_polygons,
                 alpha=polygon_alpha,
+                include_related_points=True,
             )
             for labels in label_layers
         ]

--- a/datamapplot/deckgl_template.html
+++ b/datamapplot/deckgl_template.html
@@ -249,6 +249,10 @@
         {% if search %}
         <div id="search-container" class="container-box">
           <input autocomplete="off" type="search" id="text-search" placeholder="🔍" />
+          <label id="filter-labels-label" style="font-size:0.8em; display:flex; align-items:center; gap:4px; margin-top:4px; cursor:pointer;">
+            <input type="checkbox" id="filter-labels-checkbox" />
+            Filter labels
+          </label>
         </div>
         {% endif %}
         {% if enable_topic_tree %}

--- a/datamapplot/static/js/datamap.js
+++ b/datamapplot/static/js/datamap.js
@@ -217,6 +217,7 @@ class DataMap {
     this.searchItemId = searchItemId;
     this.lassoSelectionItemId = lassoSelectionItemId;
     this.scrollZoomSpeed = scrollZoomSpeed;
+    this.filterLabelsOnSearch = false;
     this.pointData = null;
     this.labelData = null;
     this.metaData = null;
@@ -1059,6 +1060,27 @@ class DataMap {
       layers: this.layers
     });
     this.pointLayer = updatedPointLayer;
+
+    // Update label visibility when search filter is active
+    if (this.labelLayer) {
+      const filteringSearch = itemId === this.searchItemId && this.filterLabelsOnSearch && hasSelectedIndices;
+      if (!this._allLabelData) {
+        this._allLabelData = this.labelLayer.props.data;
+      }
+      const filteredData = filteringSearch
+        ? this._allLabelData.filter(d => d.relatedPoints && d.relatedPoints.some(i => selectedIndices.has(i)))
+        : this._allLabelData;
+      const updatedLabelLayer = this.labelLayer.clone({
+        data: filteredData,
+        updateTriggers: { data: this.updateTriggerCounter },
+      });
+      const labelIdx = this.layers.indexOf(this.labelLayer);
+      if (labelIdx !== -1) {
+        this.layers = [...this.layers.slice(0, labelIdx), updatedLabelLayer, ...this.layers.slice(labelIdx + 1)];
+        this.deckgl.setProps({ layers: this.layers });
+        this.labelLayer = updatedLabelLayer;
+      }
+    }
 
     // Update histogram, if any
     if (this.histogramItem && itemId !== this.histogramItemId) {

--- a/datamapplot/templates/content_layout.html.jinja2
+++ b/datamapplot/templates/content_layout.html.jinja2
@@ -83,6 +83,10 @@
       {% if search and not use_widget_system %}
       <div id="search-container" class="container-box interactive-element">
         <input autocomplete="off" type="search" id="text-search" placeholder="🔍" />
+        <label id="filter-labels-label" style="font-size:0.8em; display:flex; align-items:center; gap:4px; margin-top:4px; cursor:pointer;">
+          <input type="checkbox" id="filter-labels-checkbox" />
+          Filter labels
+        </label>
       </div>
       {% endif %}
       

--- a/datamapplot/templates/data_loaders.js.jinja2
+++ b/datamapplot/templates/data_loaders.js.jinja2
@@ -373,6 +373,13 @@ function loadMetaData() {
       if (searchItem) {
         searchItem.addEventListener("input", debounce(event => datamap.searchText(event.target.value)));
       }
+      const filterLabelsCheckbox = document.getElementById("filter-labels-checkbox");
+      if (filterLabelsCheckbox) {
+        filterLabelsCheckbox.addEventListener("change", event => {
+          datamap.filterLabelsOnSearch = event.target.checked;
+          datamap.searchText(searchItem ? searchItem.value : "");
+        });
+      }
       
       updateProgressBar('meta-data-progress', 100);
       checkAllDataLoaded();

--- a/datamapplot/templates/data_loaders.js.jinja2
+++ b/datamapplot/templates/data_loaders.js.jinja2
@@ -375,6 +375,7 @@ function loadMetaData() {
       }
       const filterLabelsCheckbox = document.getElementById("filter-labels-checkbox");
       if (filterLabelsCheckbox) {
+        filterLabelsCheckbox.checked = false;
         filterLabelsCheckbox.addEventListener("change", event => {
           datamap.filterLabelsOnSearch = event.target.checked;
           datamap.searchText(searchItem ? searchItem.value : "");


### PR DESCRIPTION
Fixes TutteInstitute/datamapplot#38.

I added a checkbox as a part of the search bar so that labels can be filtered during search. As per the issue discussion, this is unchecked by default so all labels are visible, but once checked, only labels associated with the search results are shown. Unchecking the box brings all labels back.

Summary of the code changes:
Most of the changes are just adding the checkbox in the right places and adding functionality to filter the labels. On the Python side, this only involved setting `include_related_points=True` in the `label_text_and_polygon_dataframes` call in `create_plots.py`. This then populates the `relatedPoints` field in the label JSON to ensure that labels associated with the search points are the only ones visible.

One thing to potentially flag, `include_related_points` was originally set to
`include_related_points = (True if render_html_kwds.get("topic_tree_kwds", {}).get("button_on_click") is not None else False)` in `create_plots.py`. It was unclear to me what this was meant to do with the topic trees, but setting it to `True` seemed necessary to enable the filtering. I've looked at examples with the topic tree both enabled and not and don't notice a difference qualitatively, but wanted to flag it anyway.



