### PR TITLE
Fail loudly when the offline cache is missing a dependency

### DIFF
--- a/datamapplot/__init__.py
+++ b/datamapplot/__init__.py
@@ -24,6 +24,7 @@ from datamapplot.widget_helpers import (
     merge_widget_configs,
     create_widget_from_config,
 )
+from datamapplot.offline_mode_caching import OfflineCacheError
 from datamapplot.selection_handlers import (
     SelectionHandlerBase,
     DisplaySample,
@@ -78,4 +79,6 @@ __all__ = [
     "ExportSelection",
     "Statistics",
     "Histogram",
+    # Offline mode
+    "OfflineCacheError",
 ]

--- a/datamapplot/interactive_helpers.py
+++ b/datamapplot/interactive_helpers.py
@@ -30,6 +30,7 @@ from scipy.spatial import Delaunay
 from sklearn.cluster import KMeans, MiniBatchKMeans
 from scipy.spatial import KDTree
 import datetime as dt
+from warnings import warn
 
 from datamapplot.alpha_shapes import create_boundary_polygons, smooth_polygon
 from datamapplot.fonts import can_reach_google_fonts, query_google_fonts
@@ -137,6 +138,14 @@ def get_google_font_for_embedding(fontname, offline_mode=False, offline_font_fil
                 _build_font_face_css(fontname, font_data) for font_data in encoded_fonts
             ]
             return "<style>\n" + "\n".join(font_descriptions) + "\n    </style>\n"
+        warn(
+            f"Offline mode is enabled but the font {fontname!r} is not in the "
+            f"DataMapPlot font cache, so the plot will fall back to a default "
+            f"font. Include it when building the cache:\n\n"
+            f'    dmp_offline_cache --refresh --font_names "{fontname}" ...\n\n'
+            f"--font_names replaces the cached font set rather than adding to "
+            f"it, so name every font you need in the one command."
+        )
         return ""
 
     if can_reach_google_fonts(timeout=10.0):
@@ -2917,6 +2926,8 @@ def prepare_offline_mode_data(
     offline_mode,
     offline_mode_js_data_file,
     offline_mode_font_data_file,
+    js_dependency_urls=None,
+    css_dependency_urls=None,
 ):
     """
     Prepare offline mode data by loading cached JS, CSS, and font files.
@@ -2929,12 +2940,24 @@ def prepare_offline_mode_data(
         Path to the cached JS data file.
     offline_mode_font_data_file : str or Path or None
         Path to the cached font data file.
+    js_dependency_urls : list of str, optional
+        The JavaScript dependency URLs this plot requires. When given, the
+        cache is checked for them and an ``OfflineCacheError`` is raised if any
+        are missing.
+    css_dependency_urls : list of str, optional
+        The CSS dependency URLs this plot requires. When given, the cache is
+        checked for them and a warning is issued if any are missing.
 
     Returns
     -------
     dict
         Dictionary with 'offline_mode_data', 'offline_mode_css_data', and
         'offline_mode_font_data_file' keys.
+
+    Raises
+    ------
+    OfflineCacheError
+        If ``js_dependency_urls`` is given and the cache is missing any of them.
     """
     import platformdirs
     from datamapplot import offline_mode_caching
@@ -2958,6 +2981,16 @@ def prepare_offline_mode_data(
         with open(offline_mode_js_data_file, "r") as f:
             offline_mode_data = json.load(f)
 
+    # Fail here rather than emitting a plot that hangs on its loading screen.
+    # This runs before the CSS cache is touched, since a missing CSS cache
+    # triggers a network fetch that has nothing useful to say about this.
+    if js_dependency_urls is not None:
+        offline_mode_caching.check_js_cache_coverage(
+            offline_mode_data,
+            js_dependency_urls,
+            cache_file=offline_mode_js_data_file,
+        )
+
     # Load CSS cache
     data_directory = platformdirs.user_data_dir("datamapplot")
     offline_mode_css_data_file = Path(data_directory) / "datamapplot_css_encoded.json"
@@ -2965,6 +2998,13 @@ def prepare_offline_mode_data(
         offline_mode_caching.cache_css_files()
     with offline_mode_css_data_file.open("r") as f:
         offline_mode_css_data_encoded = json.load(f)
+
+    if css_dependency_urls is not None:
+        offline_mode_caching.check_css_cache_coverage(
+            offline_mode_css_data_encoded,
+            css_dependency_urls,
+            cache_file=offline_mode_css_data_file,
+        )
 
     # Decode the base64 CSS content for direct embedding in <style> tags
     offline_mode_css_data = {}
@@ -3031,18 +3071,32 @@ def prepare_fonts(
 
     if tooltip_font_family is not None:
         api_tooltip_fontname = tooltip_font_family.replace(" ", "+")
-        resp = requests.get(
-            f"https://fonts.googleapis.com/css?family={api_tooltip_fontname}",
-            timeout=30,
-        )
-        if not resp.ok:
-            api_tooltip_fontname = None
-        else:
-            font_data += get_google_font_for_embedding(
+        if offline_mode:
+            # Resolve from the cache alone; probing Google Fonts here would
+            # defeat the point of offline mode. Mirrors the main font above:
+            # an unavailable font drops the Google Fonts <link> from the output.
+            tooltip_font_data = get_google_font_for_embedding(
                 tooltip_font_family,
-                offline_mode=offline_mode,
-                offline_font_file=offline_mode_font_data_file if offline_mode else None,
+                offline_mode=True,
+                offline_font_file=offline_mode_font_data_file,
             )
+            if tooltip_font_data == "":
+                api_tooltip_fontname = None
+            else:
+                font_data += tooltip_font_data
+        else:
+            resp = requests.get(
+                f"https://fonts.googleapis.com/css?family={api_tooltip_fontname}",
+                timeout=30,
+            )
+            if not resp.ok:
+                api_tooltip_fontname = None
+            else:
+                font_data += get_google_font_for_embedding(
+                    tooltip_font_family,
+                    offline_mode=False,
+                    offline_font_file=None,
+                )
     else:
         api_tooltip_fontname = None
 

--- a/datamapplot/interactive_rendering.py
+++ b/datamapplot/interactive_rendering.py
@@ -1477,6 +1477,8 @@ def render_html(
         offline_mode,
         offline_mode_js_data_file,
         offline_mode_font_data_file,
+        js_dependency_urls=dependencies_ctx["js_dependency_urls"],
+        css_dependency_urls=dependencies_ctx["css_dependency_urls"],
     )
     offline_mode_data = offline_result["offline_mode_data"]
     offline_mode_css_data = offline_result["offline_mode_css_data"]

--- a/datamapplot/offline_mode_caching.py
+++ b/datamapplot/offline_mode_caching.py
@@ -65,6 +65,125 @@ DEFAULT_CACHE_FILES = {
     "fonts": f"{_DATA_DIRECTORY}/datamapplot_fonts_encoded.json",
 }
 
+_REFRESH_INSTRUCTIONS = """\
+The cache is keyed by exact URL, so a cache built by an older version of
+DataMapPlot has no entry for a dependency whose URL has changed since (for
+example when a dependency gets pinned to a specific version). Refresh it with:
+
+    dmp_offline_cache --refresh
+
+If this machine has no internet access, build the cache on a connected machine
+and carry it across:
+
+    dmp_offline_cache --export dmp-cache.zip   # on the connected machine
+    dmp_offline_cache --import dmp-cache.zip   # on this machine\
+"""
+
+
+class OfflineCacheError(Exception):
+    """Raised when offline mode is requested but the cache cannot satisfy it.
+
+    Attributes
+    ----------
+    missing_urls : list of str
+        The dependency URLs that had no entry in the cache.
+    """
+
+    def __init__(self, message: str, missing_urls: Sequence[str]) -> None:
+        super().__init__(message)
+        self.missing_urls = list(missing_urls)
+
+
+def missing_cache_entries(cache, urls):
+    """List the URLs that have no entry in a loaded cache dictionary.
+
+    Parameters
+    ----------
+    cache : dict or None
+        A loaded cache dictionary, keyed by dependency URL.
+    urls : iterable of str
+        The dependency URLs that are required for rendering.
+
+    Returns
+    -------
+    list of str
+        The required URLs that are absent from the cache, in the given order.
+    """
+    if not cache:
+        return list(urls)
+    return [url for url in urls if url not in cache]
+
+
+def _describe_missing(missing, kind, cache_file):
+    location = f" at\n{cache_file}" if cache_file is not None else ""
+    count = (
+        f"1 required {kind} dependency is"
+        if len(missing) == 1
+        else f"{len(missing)} required {kind} dependencies are"
+    )
+    listing = "\n".join(f"    {url}" for url in missing)
+    return (
+        f"Offline mode is enabled but {count} missing from the "
+        f"DataMapPlot cache{location}:\n\n{listing}"
+    )
+
+
+def check_js_cache_coverage(js_cache, js_urls, cache_file=None):
+    """Verify that every required JavaScript dependency is cached.
+
+    A JavaScript dependency that is missing from the cache is fatal: the
+    rendered plot loads none of it and hangs on the loading screen, so this
+    raises rather than letting a broken plot be written out.
+
+    Parameters
+    ----------
+    js_cache : dict or None
+        The loaded JavaScript cache, keyed by dependency URL.
+    js_urls : iterable of str
+        The JavaScript dependency URLs required for this plot.
+    cache_file : str or Path, optional
+        Path of the cache file, used to make the error message actionable.
+
+    Raises
+    ------
+    OfflineCacheError
+        If any required URL is absent from the cache.
+    """
+    missing = missing_cache_entries(js_cache, js_urls)
+    if not missing:
+        return
+    raise OfflineCacheError(
+        f"{_describe_missing(missing, 'JavaScript', cache_file)}\n\n"
+        f"The rendered plot would not load, so nothing has been written.\n\n"
+        f"{_REFRESH_INSTRUCTIONS}",
+        missing,
+    )
+
+
+def check_css_cache_coverage(css_cache, css_urls, cache_file=None):
+    """Warn about any required CSS dependency that is not cached.
+
+    Unlike JavaScript, missing CSS only degrades appearance, so this warns and
+    lets rendering continue.
+
+    Parameters
+    ----------
+    css_cache : dict or None
+        The loaded CSS cache, keyed by dependency URL.
+    css_urls : iterable of str
+        The CSS dependency URLs required for this plot.
+    cache_file : str or Path, optional
+        Path of the cache file, used to make the warning message actionable.
+    """
+    missing = missing_cache_entries(css_cache, css_urls)
+    if not missing:
+        return
+    warn(
+        f"{_describe_missing(missing, 'CSS', cache_file)}\n\n"
+        f"The plot will still load, but the affected components will be "
+        f"unstyled.\n\n{_REFRESH_INSTRUCTIONS}"
+    )
+
 
 def fetch_js_content(url):
     response = requests.get(url)
@@ -497,8 +616,7 @@ class ConfirmInteractiveStdio(EquivalenceClass):
         return confirmed
 
     def print_help(self) -> None:
-        print(
-            """\
+        print("""\
 
 Type the number of an item to select it: 2
 
@@ -516,8 +634,7 @@ Type Enter to make the command happen, forcing the selection menu to refresh.
 
 You can type multiple commands ahead of Enter: 1 3 2-4 7 .
 selects items 1, 2, 4 and 7 (3 was selected, then deselected by the interval),
-then proceeds."""
-        )
+then proceeds.""")
 
 
 class ConfirmYes(EquivalenceClass):

--- a/datamapplot/templates/head_dependencies.html.jinja2
+++ b/datamapplot/templates/head_dependencies.html.jinja2
@@ -66,7 +66,7 @@
     loadBase64Script({{ offline_mode_data[url]["name"] }});
     {% else -%}
     console.error('Offline mode error: URL not found in cache: {{ url }}');
-    console.error('Please regenerate the offline cache by running: python -m datamapplot.offline_mode_caching');
+    console.error('Please regenerate the offline cache by running: dmp_offline_cache --refresh');
     {% endif -%}
   {% endfor -%}
 </script>

--- a/datamapplot/tests/test_offline_cache_validation.py
+++ b/datamapplot/tests/test_offline_cache_validation.py
@@ -1,0 +1,354 @@
+"""Tests for offline cache coverage checks (issue #205).
+
+The offline cache is keyed by exact dependency URL, so a cache built by an
+older version of DataMapPlot silently stops satisfying a dependency whose URL
+has since changed. Before these checks the only symptom was a ``console.error``
+in the browser and a plot stuck on its loading screen.
+"""
+
+import json
+import tempfile
+import unittest
+import warnings
+from contextlib import contextmanager
+from pathlib import Path
+from unittest.mock import patch
+
+import numpy as np
+
+import datamapplot
+from datamapplot import offline_mode_caching
+from datamapplot.interactive_helpers import (
+    get_google_font_for_embedding,
+    prepare_fonts,
+    prepare_offline_mode_data,
+)
+from datamapplot.offline_mode_caching import (
+    OfflineCacheError,
+    check_css_cache_coverage,
+    check_js_cache_coverage,
+    missing_cache_entries,
+)
+
+# The deck.gl URL as it was before it got pinned in 0.7.3 (PR #193). A cache
+# built by 0.7.2 or earlier is keyed on this and has no entry for the pinned
+# URL that 0.7.3 asks for.
+UNPINNED_DECKGL_URL = "https://unpkg.com/deck.gl@latest/dist.min.js"
+PINNED_DECKGL_URL = "https://unpkg.com/deck.gl@9.1/dist.min.js"
+
+
+@contextmanager
+def user_warnings_recorded():
+    """Capture UserWarnings, since ``assertWarns`` has no negative counterpart."""
+    caught = []
+    with warnings.catch_warnings(record=True) as recorded:
+        warnings.simplefilter("always")
+        yield caught
+    caught.extend(
+        str(w.message) for w in recorded if issubclass(w.category, UserWarning)
+    )
+
+
+def _fake_cache_entry(url):
+    return {
+        "encoded_content": "Y29udGVudA==",
+        "name": "".join(c if c.isalnum() else "_" for c in url),
+    }
+
+
+def _js_cache(urls):
+    return {url: _fake_cache_entry(url) for url in urls}
+
+
+def _current_js_cache():
+    """A cache with an entry for every dependency this version can ask for."""
+    return _js_cache(offline_mode_caching.DEFAULT_URLS)
+
+
+def _stale_js_cache():
+    """A cache as an older DataMapPlot would have built it."""
+    urls = [
+        UNPINNED_DECKGL_URL if url == PINNED_DECKGL_URL else url
+        for url in offline_mode_caching.DEFAULT_URLS
+    ]
+    return _js_cache(urls)
+
+
+FONT_CACHE = {
+    "Roboto": [
+        {
+            "style": "normal",
+            "weight": "400",
+            "unicode_range": "",
+            "type": "ttf",
+            "content": "Um9ib3RvRm9udENvbnRlbnQ=",
+        }
+    ]
+}
+
+
+class TestMissingCacheEntries(unittest.TestCase):
+    """The primitive the checks are built on."""
+
+    def test_reports_absent_urls_in_order(self):
+        cache = _js_cache(["https://a", "https://c"])
+        self.assertEqual(
+            missing_cache_entries(cache, ["https://a", "https://b", "https://d"]),
+            ["https://b", "https://d"],
+        )
+
+    def test_full_cache_reports_nothing(self):
+        cache = _js_cache(["https://a", "https://b"])
+        self.assertEqual(missing_cache_entries(cache, ["https://a"]), [])
+
+    def test_empty_cache_reports_everything(self):
+        for cache in ({}, None):
+            with self.subTest(cache=cache):
+                self.assertEqual(
+                    missing_cache_entries(cache, ["https://a", "https://b"]),
+                    ["https://a", "https://b"],
+                )
+
+
+class TestJsCacheCoverage(unittest.TestCase):
+    """Missing JavaScript is fatal: the plot cannot load without it."""
+
+    def test_complete_cache_passes(self):
+        cache = _current_js_cache()
+        check_js_cache_coverage(cache, offline_mode_caching.DEFAULT_URLS)
+
+    def test_missing_url_raises(self):
+        with self.assertRaises(OfflineCacheError) as ctx:
+            check_js_cache_coverage(_stale_js_cache(), [PINNED_DECKGL_URL])
+        self.assertEqual(ctx.exception.missing_urls, [PINNED_DECKGL_URL])
+
+    def test_error_message_is_actionable(self):
+        with self.assertRaises(OfflineCacheError) as ctx:
+            check_js_cache_coverage(
+                _stale_js_cache(),
+                [PINNED_DECKGL_URL],
+                cache_file="/somewhere/datamapplot_js_encoded.json",
+            )
+        message = str(ctx.exception)
+        # Names the dependency, where the cache lives, and how to fix it.
+        self.assertIn(PINNED_DECKGL_URL, message)
+        self.assertIn("/somewhere/datamapplot_js_encoded.json", message)
+        self.assertIn("dmp_offline_cache --refresh", message)
+        self.assertIn("dmp_offline_cache --export", message)
+
+    def test_message_counts_multiple_missing_urls(self):
+        with self.assertRaises(OfflineCacheError) as ctx:
+            check_js_cache_coverage({}, ["https://a", "https://b"])
+        self.assertIn(
+            "2 required JavaScript dependencies are missing", str(ctx.exception)
+        )
+
+
+class TestCssCacheCoverage(unittest.TestCase):
+    """Missing CSS only costs styling, so it warns rather than raising."""
+
+    def test_complete_cache_is_silent(self):
+        cache = _js_cache(offline_mode_caching.DEFAULT_CSS_URLS)
+        with user_warnings_recorded() as caught:
+            check_css_cache_coverage(cache, offline_mode_caching.DEFAULT_CSS_URLS)
+        self.assertEqual(caught, [])
+
+    def test_missing_url_warns(self):
+        css_url = "https://cdn.datatables.net/1.13.8/css/jquery.dataTables.min.css"
+        with self.assertWarns(UserWarning) as ctx:
+            check_css_cache_coverage({}, [css_url])
+        message = str(ctx.warning)
+        self.assertIn(css_url, message)
+        self.assertIn("dmp_offline_cache --refresh", message)
+
+
+class TestPrepareOfflineModeData(unittest.TestCase):
+    """The checks as wired into the render path."""
+
+    def setUp(self):
+        self._temp_dir = tempfile.TemporaryDirectory()
+        self.data_directory = Path(self._temp_dir.name)
+        self.addCleanup(self._temp_dir.cleanup)
+
+        # A complete CSS and font cache, so only the JS cache under test varies.
+        self.write_cache(
+            "datamapplot_css_encoded.json",
+            _js_cache(offline_mode_caching.DEFAULT_CSS_URLS),
+        )
+        self.write_cache("datamapplot_fonts_encoded.json", FONT_CACHE)
+
+        patcher = patch(
+            "platformdirs.user_data_dir", return_value=str(self.data_directory)
+        )
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+    def write_cache(self, name, contents):
+        path = self.data_directory / name
+        with path.open("w") as f:
+            json.dump(contents, f)
+        return path
+
+    def test_missing_js_dependency_raises(self):
+        js_cache_file = self.write_cache(
+            "datamapplot_js_encoded.json", _stale_js_cache()
+        )
+        with self.assertRaises(OfflineCacheError) as ctx:
+            prepare_offline_mode_data(
+                True,
+                str(js_cache_file),
+                None,
+                js_dependency_urls=[PINNED_DECKGL_URL],
+            )
+        self.assertEqual(ctx.exception.missing_urls, [PINNED_DECKGL_URL])
+
+    def test_complete_js_cache_passes(self):
+        js_cache_file = self.write_cache(
+            "datamapplot_js_encoded.json", _current_js_cache()
+        )
+        result = prepare_offline_mode_data(
+            True,
+            str(js_cache_file),
+            None,
+            js_dependency_urls=[PINNED_DECKGL_URL],
+            css_dependency_urls=offline_mode_caching.DEFAULT_CSS_URLS,
+        )
+        self.assertIn(PINNED_DECKGL_URL, result["offline_mode_data"])
+
+    def test_missing_css_dependency_warns_and_continues(self):
+        js_cache_file = self.write_cache(
+            "datamapplot_js_encoded.json", _current_js_cache()
+        )
+        css_url = "https://example.com/uncached.css"
+        with self.assertWarns(UserWarning):
+            result = prepare_offline_mode_data(
+                True,
+                str(js_cache_file),
+                None,
+                js_dependency_urls=[PINNED_DECKGL_URL],
+                css_dependency_urls=[css_url],
+            )
+        self.assertIsNotNone(result["offline_mode_data"])
+
+    def test_urls_are_optional(self):
+        """Callers that pass no URLs get the previous unchecked behaviour."""
+        js_cache_file = self.write_cache("datamapplot_js_encoded.json", {})
+        result = prepare_offline_mode_data(True, str(js_cache_file), None)
+        self.assertEqual(result["offline_mode_data"], {})
+
+    def test_online_mode_is_unaffected(self):
+        result = prepare_offline_mode_data(
+            False, None, None, js_dependency_urls=[PINNED_DECKGL_URL]
+        )
+        self.assertIsNone(result["offline_mode_data"])
+
+
+class TestInteractivePlotWithStaleCache(unittest.TestCase):
+    """End-to-end: the failure reported in issue #205."""
+
+    def setUp(self):
+        np.random.seed(42)
+        self.data_coords = np.random.randn(100, 2)
+        self.labels = np.array(["Group A"] * 50 + ["Group B"] * 50)
+
+        self._temp_dir = tempfile.TemporaryDirectory()
+        self.data_directory = Path(self._temp_dir.name)
+        self.addCleanup(self._temp_dir.cleanup)
+
+        for name, contents in [
+            (
+                "datamapplot_css_encoded.json",
+                _js_cache(offline_mode_caching.DEFAULT_CSS_URLS),
+            ),
+            ("datamapplot_fonts_encoded.json", FONT_CACHE),
+        ]:
+            with (self.data_directory / name).open("w") as f:
+                json.dump(contents, f)
+
+        patcher = patch(
+            "platformdirs.user_data_dir", return_value=str(self.data_directory)
+        )
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+    def js_cache_file(self, contents):
+        path = self.data_directory / "js_cache.json"
+        with path.open("w") as f:
+            json.dump(contents, f)
+        return str(path)
+
+    def test_stale_cache_raises_instead_of_rendering_a_broken_plot(self):
+        with self.assertRaises(OfflineCacheError) as ctx:
+            datamapplot.create_interactive_plot(
+                self.data_coords,
+                self.labels,
+                offline_mode=True,
+                offline_mode_js_data_file=self.js_cache_file(_stale_js_cache()),
+            )
+        self.assertIn(PINNED_DECKGL_URL, ctx.exception.missing_urls)
+
+    def test_current_cache_still_renders(self):
+        fig = datamapplot.create_interactive_plot(
+            self.data_coords,
+            self.labels,
+            offline_mode=True,
+            offline_mode_js_data_file=self.js_cache_file(_current_js_cache()),
+        )
+        self.assertIsInstance(fig, datamapplot.interactive_rendering.InteractiveFigure)
+
+
+class TestOfflineFontHandling(unittest.TestCase):
+    """Fonts degrade gracefully, but no longer silently."""
+
+    def test_uncached_font_warns(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            font_cache_path = Path(temp_dir) / "fonts.json"
+            with font_cache_path.open("w") as f:
+                json.dump(FONT_CACHE, f)
+
+            with self.assertWarns(UserWarning) as ctx:
+                result = get_google_font_for_embedding(
+                    "Cinzel",
+                    offline_mode=True,
+                    offline_font_file=str(font_cache_path),
+                )
+            self.assertEqual(result, "")
+            self.assertIn("Cinzel", str(ctx.warning))
+            self.assertIn("dmp_offline_cache", str(ctx.warning))
+
+    def test_cached_font_does_not_warn(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            font_cache_path = Path(temp_dir) / "fonts.json"
+            with font_cache_path.open("w") as f:
+                json.dump(FONT_CACHE, f)
+
+            with user_warnings_recorded() as caught:
+                result = get_google_font_for_embedding(
+                    "Roboto",
+                    offline_mode=True,
+                    offline_font_file=str(font_cache_path),
+                )
+            self.assertIn("@font-face", result)
+            self.assertEqual(caught, [])
+
+    def test_tooltip_font_does_not_reach_out_to_google_fonts(self):
+        """Offline mode must resolve the tooltip font from the cache alone."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            font_cache_path = Path(temp_dir) / "fonts.json"
+            with font_cache_path.open("w") as f:
+                json.dump(FONT_CACHE, f)
+
+            with patch("requests.get", side_effect=AssertionError("network used")):
+                result = prepare_fonts(
+                    "Roboto",
+                    "Roboto",
+                    [],
+                    True,
+                    str(font_cache_path),
+                )
+            self.assertEqual(result["api_tooltip_fontname"], "Roboto")
+            self.assertIn("@font-face", result["font_data"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/datamapplot/tests/test_offline_font_file_handling.py
+++ b/datamapplot/tests/test_offline_font_file_handling.py
@@ -5,6 +5,7 @@ import numpy as np
 from pathlib import Path
 from unittest.mock import patch, MagicMock
 import datamapplot
+from datamapplot import offline_mode_caching
 from datamapplot.interactive_rendering import get_google_font_for_embedding
 
 
@@ -96,28 +97,15 @@ class TestOfflineFontFileHandling(unittest.TestCase):
                 ]
             }
 
-            # Need all required JS files for offline mode
+            # Need all required JS files for offline mode. Derived from
+            # DEFAULT_URLS so that pinning a dependency to a new version does
+            # not leave this cache stale, which is the failure behind #205.
             mock_js_data = {
-                "https://unpkg.com/deck.gl@latest/dist.min.js": {
-                    "encoded_content": "ZGVja2dsX2NvbnRlbnQ=",
-                    "name": "unpkg_com_deck_gl_latest_dist_min_js",
-                },
-                "https://unpkg.com/apache-arrow@latest/Arrow.es2015.min.js": {
-                    "encoded_content": "YXJyb3dfY29udGVudA==",
-                    "name": "unpkg_com_apache_arrow_latest_Arrow_es2015_min_js",
-                },
-                "https://unpkg.com/d3@latest/dist/d3.min.js": {
-                    "encoded_content": "ZDNfY29udGVudA==",
-                    "name": "unpkg_com_d3_latest_dist_d3_min_js",
-                },
-                "https://unpkg.com/jquery@3.7.1/dist/jquery.min.js": {
-                    "encoded_content": "anF1ZXJ5X2NvbnRlbnQ=",
-                    "name": "unpkg_com_jquery_3_7_1_dist_jquery_min_js",
-                },
-                "https://unpkg.com/d3-cloud@1.2.7/build/d3.layout.cloud.js": {
-                    "encoded_content": "ZDNfY2xvdWRfY29udGVudA==",
-                    "name": "unpkg_com_d3_cloud_1_2_7_build_d3_layout_cloud_js",
-                },
+                url: {
+                    "encoded_content": "ZmFrZV9jb250ZW50",
+                    "name": "".join(c if c.isalnum() else "_" for c in url),
+                }
+                for url in offline_mode_caching.DEFAULT_URLS
             }
 
             with open(font_cache_path, "w") as f:


### PR DESCRIPTION
Closes #205.

## The problem

The offline cache is keyed by **exact dependency URL**. `prepare_offline_mode_data` builds the cache only when the file is *absent*, so an existing cache is loaded as-is and an upgrade never invalidates it.

That is what broke #205: pinning deck.gl in #193 changed the URL from `deck.gl@latest/dist.min.js` to `deck.gl@9.1/dist.min.js`, so a cache built by 0.7.2 or earlier has no entry for the URL 0.7.3 asks for. The only symptom was a `console.error` in the browser and a plot stuck at 0% on its loading screen — nothing on the Python side said a word. `apache-arrow` and `d3` are still on `@latest`, so any future pin re-breaks every existing cache the same way.

## The change

Coverage is now checked at render time, with severity matched to what actually breaks:

- **A missing JavaScript dependency raises `OfflineCacheError`.** Without it the plot cannot load at all, so no plot is written. The message names each missing URL, the cache file it looked in, and the fix:

  ```
  OfflineCacheError: Offline mode is enabled but 1 required JavaScript dependency is missing from the DataMapPlot cache at
  /home/u/.local/share/datamapplot/datamapplot_js_encoded.json:

      https://unpkg.com/deck.gl@9.1/dist.min.js

  The rendered plot would not load, so nothing has been written.

  The cache is keyed by exact URL, so a cache built by an older version of
  DataMapPlot has no entry for a dependency whose URL has changed since (for
  example when a dependency gets pinned to a specific version). Refresh it with:

      dmp_offline_cache --refresh

  If this machine has no internet access, build the cache on a connected machine
  and carry it across:

      dmp_offline_cache --export dmp-cache.zip   # on the connected machine
      dmp_offline_cache --import dmp-cache.zip   # on this machine
  ```

- **A missing CSS dependency warns.** It only costs styling, so rendering continues.
- **A font missing from the offline cache warns** instead of silently falling back to a default font.

The JS check runs immediately after the JS cache loads, *before* the CSS cache is touched — a missing CSS cache triggers a network fetch, which on an air-gapped machine would otherwise fail first with a message that says nothing about the real problem.

No new keyword arguments: `OfflineCacheError` is exported from the top-level package so it can be caught, and the checks are unconditional under `offline_mode=True`.

Implementation is `check_js_cache_coverage` / `check_css_cache_coverage` in `offline_mode_caching.py`, called from `prepare_offline_mode_data`, which now takes the dependency URL lists `render_html` already computes.

## One extra fix, easy to split out

`prepare_fonts` called `requests.get("https://fonts.googleapis.com/css?family=...")` for the tooltip font **even when `offline_mode=True`** — a 30-second hang or a `ConnectionError` on an air-gapped network. It now resolves the tooltip font from the cache, mirroring how the main font is already handled. Same "offline mode must not touch the network" family as #205, but a distinct bug; happy to drop the hunk if you would rather keep this PR to the cache check alone.

## Testing

`datamapplot/tests/test_offline_cache_validation.py` covers the coverage primitives, the raise/warn split, the wiring in `prepare_offline_mode_data`, the font warning, the tooltip-font network fix, and an end-to-end reproduction of #205 (a cache keyed on the pre-pin deck.gl URL now raises rather than emitting a plot that hangs).

Worth noting: the JS cache fixture in `test_offline_font_file_handling.py` was itself keyed on `deck.gl@latest`, so it failed the moment the check landed — the regression demonstrating itself against a fixture written before the pin. It now derives from `DEFAULT_URLS` and cannot go stale the same way.

326 backend tests and 36 interactive tests pass locally.

## Docs

Added a note to `doc/offline_mode.ipynb` immediately after the cell that says cache files "will be created for you" — that is true only when they don't exist yet, which is exactly what hides this trap. The note says to rerun `dmp_offline_cache --refresh` after upgrading.

## Two things I noticed but left alone

- `DataTable` deliberately excludes the DataTables JS from `dependencies` (it is loaded dynamically after jQuery), so that URL never reaches `js_dependency_urls` and `window.offlineDataTablesScript` is never set in offline mode. The handler looks broken offline independently of this PR.
- `dmp_offline_cache --refresh --font_names X` *replaces* the cached font set rather than adding to it. The new font warning therefore tells users to name every font they need in a single command.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JXdkKdGexWqzhdfADFTD8o